### PR TITLE
Disable strict versioning

### DIFF
--- a/pkg/index/indexscanner/scanner.go
+++ b/pkg/index/indexscanner/scanner.go
@@ -104,6 +104,8 @@ func DecodePluginFile(r io.Reader) (index.Plugin, error) {
 		return plugin, err
 	}
 	decoder := json.NewDecoder(bytes.NewReader(jsonRaw))
-	decoder.DisallowUnknownFields()
+
+	// TODO(lbb): Enable strict visioning.
+	// decoder.DisallowUnknownFields()
 	return plugin, decoder.Decode(&plugin)
 }

--- a/pkg/index/indexscanner/scanner_test.go
+++ b/pkg/index/indexscanner/scanner_test.go
@@ -42,20 +42,22 @@ func Test_readIndexFile(t *testing.T) {
 				"os": "macos",
 			},
 		},
-		{
-			name: "read index file with unknown keys",
-			args: args{
-				indexFilePath: filepath.Join(testdataPath(t), "testindex", "plugins", "badplugin.yaml"),
+		/*
+			{
+				name: "read index file with unknown keys",
+				args: args{
+					indexFilePath: filepath.Join(testdataPath(t), "testindex", "plugins", "badplugin.yaml"),
+				},
+				wantErr: true,
 			},
-			wantErr: true,
-		},
-		{
-			name: "read index file with unknown keys",
-			args: args{
-				indexFilePath: filepath.Join(testdataPath(t), "testindex", "plugins", "badplugin2.yaml"),
+			{
+				name: "read index file with unknown keys",
+				args: args{
+					indexFilePath: filepath.Join(testdataPath(t), "testindex", "plugins", "badplugin2.yaml"),
+				},
+				wantErr: true,
 			},
-			wantErr: true,
-		},
+		*/
 	}
 	neverMatch := labels.Set{}
 


### PR DESCRIPTION
Currently we may want to allow cahnges to
the index manifest format. The current approach
can break users that are on old versions.