### PR TITLE
Added Fish installation-procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ For macOS and Linux:
 - Paste this command to your terminal:
 
 ```bash
+bash
 (
  set -x; cd "$(mktemp -d)" &&
  curl -fsSLO "https://storage.googleapis.com/krew-test/krew.zip" &&
  unzip krew.zip &&
  "./build/krew-$(uname | tr '[:upper:]' '[:lower:]')" install krew
 )
+exit
 ```
 
 Windows:
@@ -76,7 +78,7 @@ Read the complete [User Guide](./docs/USER_GUIDE.md) for more details.
 To publish your plugin on krew, you need to make the releases available for
 download, and contribute a plugin descriptor file to krew-index repository.
 
-Read the [Plugin Developer Guide](./docs/PLUGIN_DEVELOPER.md) for details.
+Read the [Plugin Developer Guide](./docs/DEVELOPER_GUIDE.md) for details.	
 
 # Additional Links
 


### PR DESCRIPTION
The old version was a bit misleading by implying that the installation would work that way in all shells.