### PR TITLE
krew info: Improve error message when plugin doesn't exist

### DIFF
--- a/cmd/krew/cmd/info.go
+++ b/cmd/krew/cmd/info.go
@@ -33,17 +33,16 @@ var infoCmd = &cobra.Command{
 	Short: "Info shows plugin details",
 	Long: `Info shows plugin details.
 Use this command to find out about plugin requirements and caveats.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	Run: func(cmd *cobra.Command, args []string) {
 		for _, arg := range args {
 			plugin, err := indexscanner.LoadPluginFileFromFS(paths.Index, arg)
-			if err != nil {
-				glog.V(4).Info(err.Error())
-				return fmt.Errorf("plugin %q not found\n", arg)
+			if os.IsNotExist(err) {
+				glog.Fatalf("plugin %q not found", arg)
+			} else if err != nil {
+				glog.Fatal(err)
 			}
 			printPluginInfo(os.Stdout, plugin)
 		}
-
-		return nil
 	},
 	PreRunE: checkIndex,
 	Args:    cobra.MinimumNArgs(1),

--- a/cmd/krew/cmd/info.go
+++ b/cmd/krew/cmd/info.go
@@ -33,14 +33,17 @@ var infoCmd = &cobra.Command{
 	Short: "Info shows plugin details",
 	Long: `Info shows plugin details.
 Use this command to find out about plugin requirements and caveats.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, arg := range args {
 			plugin, err := indexscanner.LoadPluginFileFromFS(paths.Index, arg)
 			if err != nil {
-				glog.Fatal(err)
+				glog.V(4).Info(err.Error())
+				return fmt.Errorf("plugin %q not found\n", arg)
 			}
 			printPluginInfo(os.Stdout, plugin)
 		}
+
+		return nil
 	},
 	PreRunE: checkIndex,
 	Args:    cobra.MinimumNArgs(1),

--- a/pkg/index/indexscanner/scanner.go
+++ b/pkg/index/indexscanner/scanner.go
@@ -64,7 +64,8 @@ func LoadPluginListFromFS(indexDir string) (index.IndexList, error) {
 	return indexList, nil
 }
 
-// LoadPluginFileFromFS loads a plugins index file by its name.
+// LoadPluginFileFromFS loads a plugins index file by its name. When plugin
+// file not found, it returns an error that can be checked with os.IsNotExist.
 func LoadPluginFileFromFS(indexDir, pluginName string) (index.Plugin, error) {
 	if !index.IsSafePluginName(pluginName) {
 		return index.Plugin{}, fmt.Errorf("plugin name %q not allowed", pluginName)
@@ -76,17 +77,22 @@ func LoadPluginFileFromFS(indexDir, pluginName string) (index.Plugin, error) {
 		return index.Plugin{}, err
 	}
 	p, err := ReadPluginFile(filepath.Join(indexDir, pluginName+".yaml"))
-	if err != nil {
+	if os.IsNotExist(err) {
+		return index.Plugin{}, err
+	} else if err != nil {
 		return index.Plugin{}, fmt.Errorf("failed to read the plugin file, err: %v", err)
 	}
 	return p, p.Validate(pluginName)
 }
 
-// ReadPluginFile loads a file from the FS
+// ReadPluginFile loads a file from the FS. When plugin file not found, it
+// returns an error that can be checked with os.IsNotExist.
 // TODO(lbb): Add object verification
 func ReadPluginFile(indexFilePath string) (index.Plugin, error) {
 	f, err := os.Open(indexFilePath)
-	if err != nil {
+	if os.IsNotExist(err) {
+		return index.Plugin{}, err
+	} else if err != nil {
 		return index.Plugin{}, fmt.Errorf("failed to open index file, err: %v", err)
 	}
 	return DecodePluginFile(f)

--- a/pkg/index/indexscanner/scanner_test.go
+++ b/pkg/index/indexscanner/scanner_test.go
@@ -15,6 +15,7 @@
 package indexscanner
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -125,9 +126,10 @@ func TestLoadIndexFileFromFS(t *testing.T) {
 		pluginName string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
+		name              string
+		args              args
+		wantErr           bool
+		wantIsNotExistErr bool
 	}{
 		{
 			name: "load single index file",
@@ -135,7 +137,8 @@ func TestLoadIndexFileFromFS(t *testing.T) {
 				indexDir:   filepath.Join(testdataPath(t), "testindex"),
 				pluginName: "foo",
 			},
-			wantErr: false,
+			wantErr:           false,
+			wantIsNotExistErr: false,
 		},
 		{
 			name: "plugin file not found",
@@ -143,7 +146,8 @@ func TestLoadIndexFileFromFS(t *testing.T) {
 				indexDir:   filepath.FromSlash("./testdata"),
 				pluginName: "not",
 			},
-			wantErr: true,
+			wantErr:           true,
+			wantIsNotExistErr: true,
 		},
 		{
 			name: "plugin file bad name",
@@ -151,7 +155,8 @@ func TestLoadIndexFileFromFS(t *testing.T) {
 				indexDir:   filepath.FromSlash("./testdata"),
 				pluginName: "wrongname",
 			},
-			wantErr: true,
+			wantErr:           true,
+			wantIsNotExistErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -159,6 +164,10 @@ func TestLoadIndexFileFromFS(t *testing.T) {
 			got, err := LoadPluginFileFromFS(tt.args.indexDir, tt.args.pluginName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("LoadIndexFileFromFS() got = %##v,error = %v, wantErr %v", got, err, tt.wantErr)
+				return
+			}
+			if os.IsNotExist(err) != tt.wantIsNotExistErr {
+				t.Errorf("LoadIndexFileFromFS() got = %##v,error = %v, wantIsNotExistErr %v", got, err, tt.wantErr)
 				return
 			}
 		})


### PR DESCRIPTION
This PR improves `krew info`'s error message when plugin does not exist.

```
$ kubectl plugin info hoge
Error: plugin "hoge" not found

Usage:
  krew info [flags]

Flags:
  -h, --help   help for info

Global Flags:
      --alsologtostderr                  log to standard error as well as files
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --logtostderr                      log to standard error instead of files (default true)
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
  -v, --v Level                          log level for V logs
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

F0728 17:28:23.820914    6508 root.go:49] plugin "hoge" not found
```

/fix #12