### PR TITLE
krew search: doesn't output header when no plugins found

### DIFF
--- a/cmd/krew/cmd/search.go
+++ b/cmd/krew/cmd/search.go
@@ -61,6 +61,11 @@ Search accepts a list of words as options.`,
 			matchNames = names
 		}
 
+		// No plugins found
+		if len(matchNames) == 0 {
+			return nil
+		}
+
 		rowPattern := "%s\t%s\t%s\n"
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
 		fmt.Fprintf(w, rowPattern, "NAME", "DESCRIPTION", "STATUS")


### PR DESCRIPTION
This PR improves krew search not to output header when no plugins found.

/fix #13 