### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,20 @@ For macOS and Linux:
 
 ```bash
 (
- set -x; cd "$(mktemp -d)" &&
- curl -fsSLO "https://storage.googleapis.com/krew-test/krew.zip" &&
- unzip krew.zip &&
- "./build/krew-$(uname | tr '[:upper:]' '[:lower:]')" install krew
+set -x; cd "$(mktemp -d)" &&
+curl -fsSLO "https://github.com/GoogleContainerTools/krew/releases/download/v0.1.0-alpha.1/krew.zip" &&
+unzip krew.zip &&
+"./out/build/krew-$(uname | tr '[:upper:]' '[:lower:]')" install krew
 )
 ```
 
 Windows:
 
 1. Make sure that git is installed
-2. Download https://storage.googleapis.com/krew-test/krew.zip
+2. Download https://github.com/GoogleContainerTools/krew/releases/download/v0.1.0-alpha.1/krew.zip
 3. Unzip the file
 4. Launch a command-line window in the extracted directory
-5. Run: ./krew-windows.exe install krew
+5. Run: ./out/build/krew-windows.exe install krew
 
 To verify the installation run `kubectl plugin`.
 You should see new subcommands.


### PR DESCRIPTION
This fixes the installation to be compatible with the https://github.com/GoogleContainerTools/krew/releases/tag/v0.1.0-alpha.1 release