### PR TITLE
pkg/version: add git version stamps to krew binary

### DIFF
--- a/cmd/krew/cmd/version.go
+++ b/cmd/krew/cmd/version.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/GoogleContainerTools/krew/pkg/version"
 	"github.com/spf13/cobra"
 )
 
@@ -37,6 +38,8 @@ DownloadPath is the path used to store download binaries.`,
 		conf := map[string]string{
 			"IsPlugin":        fmt.Sprintf("%v", krewExecutedVersion != ""),
 			"ExecutedVersion": krewExecutedVersion,
+			"GitTag":          version.GitTag(),
+			"GitCommit":       version.GitCommit(),
 			"BasePath":        paths.Base,
 			"IndexPath":       paths.Index,
 			"IndexURI":        IndexURI,

--- a/hack/build-cross-releases.sh
+++ b/hack/build-cross-releases.sh
@@ -22,7 +22,12 @@ cd "${SCRIPTDIR}/.."
 
 # Builds
 rm -rf out/
-gox -os="linux darwin windows" -arch="amd64" -output="out/build/krew-{{.OS}}" ./cmd/krew/...
+gox -os="linux darwin windows" -arch="amd64" \
+  -ldflags="-X github.com/GoogleContainerTools/krew/pkg/version.gitCommit=$(git rev-parse --short HEAD) \
+    -X github.com/GoogleContainerTools/krew/pkg/version.gitTag=$(git describe --tags --dirty --always)" \
+  -output="out/build/krew-{{.OS}}" \
+  ./cmd/krew/...
+
 go install github.com/GoogleContainerTools/krew/cmd/krew-manifest
 
 (

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,28 @@
+// Package version contains the version information of the krew binary.
+package version
+
+var (
+	// gitCommit contains the git commit idenifier.
+	gitCommit string
+
+	// gitTag contains the git tag or describe output.
+	gitTag string
+)
+
+// GitCommit returns the value stamped into the binary at compile-time or a
+// default "unknown" value.
+func GitCommit() string {
+	if gitCommit == "" {
+		return "unknown"
+	}
+	return gitCommit
+}
+
+// GitTag returns the value stamped into the binary at compile-time or a
+// default "unknown" value.
+func GitTag() string {
+	if gitTag == "" {
+		return "unknown"
+	}
+	return gitTag
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,33 @@
+package version
+
+import "testing"
+
+func TestGitCommit(t *testing.T) {
+	orig := gitCommit
+	defer func() { gitCommit = orig }()
+
+	gitCommit = ""
+	if v := GitCommit(); v != "unknown" {
+		t.Errorf("empty gitCommit, expected=\"unknown\" got=%q", v)
+	}
+
+	gitCommit = "abcdef"
+	if v := GitCommit(); v != "abcdef" {
+		t.Errorf("empty gitCommit, expected=\"abcdef\" got=%q", v)
+	}
+}
+
+func TestGitTag(t *testing.T) {
+	orig := gitTag
+	defer func() { gitTag = orig }()
+
+	gitTag = ""
+	if v := GitTag(); v != "unknown" {
+		t.Errorf("empty gitTag, expected=\"unknown\" got=%q", v)
+	}
+
+	gitTag = "abcdef"
+	if v := GitTag(); v != "abcdef" {
+		t.Errorf("empty gitTag, expected=\"abcdef\" got=%q", v)
+	}
+}


### PR DESCRIPTION
I'm not entirely sure if we need both GitTag and GitCommit. This is primarily
for tagging release binaries easily (where the git repo is supposed to exist).

Fixes #20.