### PR TITLE
Make macOS/Linux install command less scary and exotic

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,10 @@ For macOS and Linux:
 - Paste this command to your terminal:
 
 ```bash
-(
-  set -x; cd "$(mktemp -d)" &&
-  curl -fsSLO "https://github.com/GoogleContainerTools/krew/releases/download/v0.1.0-alpha.1/krew.zip" &&
-  unzip krew.zip &&
-  "./out/build/krew-$(uname | tr '[:upper:]' '[:lower:]')" install krew
-)
+cd "$(mktemp -d)" \
+  && curl -LO "https://github.com/GoogleContainerTools/krew/releases/download/v0.1.0-alpha.1/krew.zip" \
+  && unzip krew.zip \
+  && "./out/build/krew-$(uname | tr '[:upper:]' '[:lower:]')" install krew
 ```
 
 Windows:


### PR DESCRIPTION
Remove the subshell, omit debug mode (-x), and apply our shell style guide: https://google.github.io/styleguide/shell.xml