### PR TITLE
add breaking change notice to all krew cmds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 out/
 build/
+coverage.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,38 @@
 sudo: false
-
 language: go
-
 go:
-  - 1.10.x
-
+- 1.10.x
 go_import_path: github.com/GoogleContainerTools/krew
-
 git:
   depth: 1
-
 install: true
-
 notifications:
   email: false
-
 before_install:
-  - go get github.com/mitchellh/gox
-  - go get gopkg.in/alecthomas/gometalinter.v2
-  - gometalinter.v2 --install
-
+- go get github.com/mitchellh/gox
+- go get gopkg.in/alecthomas/gometalinter.v2
+- gometalinter.v2 --install
 script:
-  - hack/gofmt.sh
-  - hack/gometalinter.sh
-  - go test -v -cover ./...
-  - hack/build-cross-releases.sh
-
+- hack/gofmt.sh
+- hack/gometalinter.sh
+- go test -v -coverprofile=coverage.txt -covermode=atomic ./...
+- hack/build-cross-releases.sh
+after_success:
+- bash <(curl -s https://codecov.io/bash)
 deploy:
   provider: releases
   api_key:
-    secure: "f1xHUbLggyRUFikISqZM0VVsmSJFbZnLPMyiqsjZojwhmmAzRvAqZBuhAXGmFINNxf/UjTY+akVnpC/tlyW9h+KmSjpo+xx5shWX3vFPIAW909B57I0ZCpdhn+VOR17C7mAKW6apFAAVs5PrWdeoYSmRDHyMfIUhljwn+/Uw08b/OhaSYjOoxaeM+1FIYvILKx/3+b31pqH6HvQp9q8loLO7fYEMp7kTW/pQ+gSP7F6oEeZmYqwmGQ6+o4UlVldky4Aix6MQFfE1lFnTfyi6GtlMWLVALEfN7Z3CxdrwE5KFo/yguG1PmlfWx8TzqU6kr9u+EsaDez2FHi+5KabFZWd9sp/dyoN+MrqY5LTb+Rr12Uoyo9gvRu9lj75K7O73AwYKVf697YpMy8XXcM3C1QLcwjhePt3jKM7rv7grJab73EedEmUvCJxtQDXiVG2YoMRmr71z2LNKeP1G+yu0a4qHOpbo7l9x/HrQsVMsJ7p0l2/7bSrtZzS2i/atn8i2D8iKHIEu0ygHyZEQDO6wR9tzj+3qsCKS8O21vOf/pSD4VWXeeOdvenqkCaftRZoyFCbvpQn0z/IY1p2lJCJhSKAmnfOlIgDdylSTy1jOArShxa0HC/JC67f8TgUYvg6WYdejuK5UJtEWv6tADrk702JOMHIC1ILUIeEjy16pb/g="
+    secure: f1xHUbLggyRUFikISqZM0VVsmSJFbZnLPMyiqsjZojwhmmAzRvAqZBuhAXGmFINNxf/UjTY+akVnpC/tlyW9h+KmSjpo+xx5shWX3vFPIAW909B57I0ZCpdhn+VOR17C7mAKW6apFAAVs5PrWdeoYSmRDHyMfIUhljwn+/Uw08b/OhaSYjOoxaeM+1FIYvILKx/3+b31pqH6HvQp9q8loLO7fYEMp7kTW/pQ+gSP7F6oEeZmYqwmGQ6+o4UlVldky4Aix6MQFfE1lFnTfyi6GtlMWLVALEfN7Z3CxdrwE5KFo/yguG1PmlfWx8TzqU6kr9u+EsaDez2FHi+5KabFZWd9sp/dyoN+MrqY5LTb+Rr12Uoyo9gvRu9lj75K7O73AwYKVf697YpMy8XXcM3C1QLcwjhePt3jKM7rv7grJab73EedEmUvCJxtQDXiVG2YoMRmr71z2LNKeP1G+yu0a4qHOpbo7l9x/HrQsVMsJ7p0l2/7bSrtZzS2i/atn8i2D8iKHIEu0ygHyZEQDO6wR9tzj+3qsCKS8O21vOf/pSD4VWXeeOdvenqkCaftRZoyFCbvpQn0z/IY1p2lJCJhSKAmnfOlIgDdylSTy1jOArShxa0HC/JC67f8TgUYvg6WYdejuK5UJtEWv6tADrk702JOMHIC1ILUIeEjy16pb/g=
   file:
-  - "out/krew.zip"
-  - "out/krew-zip.sha256"
-  - "out/build/krew-linux"
-  - "out/build/krew-darwin"
-  - "out/build/krew-windows.exe"
+  - out/krew.zip
+  - out/krew-zip.sha256
+  - out/build/krew-linux
+  - out/build/krew-darwin
+  - out/build/krew-windows.exe
   skip_cleanup: true
   on:
     tags: true
+env:
+  global:
+  - secure: Ly5oLE9sC7NDvwyZEzOi8gPeHdu3NTP2OuDa8BOUngAanXhaEInzBJ+Pod+TIKFzpope4/z8idMN3rZfPV5LcXzhufk82LSpYlGhZgFDYajvv3eNN20arZQf4kjohd5U2aY1XrYgrgBbodv7dCLnitxotO65tTzQN5xh6evwW6Ji2Em7t42kvz9VHj2nptWKsciQEr6KNb2xDJ7PSvFKdPKq0q3Vuy7PFToZvNbsk+FBLSjYpAHG1KrlyX/WiM1mLu7jCJ4yuPx4n9+CM5Zzycbc/6mrs8ZiR+myyaCMzh6pEltdR0vzSlFIl2TJvUwzTUyTXcZsQ/ENa1ZdOkQwI4jpV3IDTQ6AlMRtBSbL5/uSOvHYs1HBYTbJJeZLiMjru9SM6D9AUW9HRr0JQGeQFsPE/4mzl39Xgl+3GE4+6sfNiaurpvgNArQNBAs2nZ0V3myiDoSG/sAL/2YzXHiG0HVhVk65P33d9SevJjBJRTobhRf4Lt0lT2IO6XF/4kQIvMnaCPQRS1X5tMIHFeTzn1dwrFiZqd1Sbwq5cd8H25nt1XnXsCTgRegJPNUxqRHnDpR5M3HRiW+TmjJIte7Y6exCihonM3afj3rsu3Q/ePwj7ckzgq8CP2yJ//Sxu4FH65LGQ/2bHJUneKL33Uq1W68c+qtKWMGLB4LNRGJVZkc=
+  - secure: o6ZTdC1H4elXUrqt8XFfV7zuN9mWjQcV5iMicyG7TU/Fn8HIOluzRYPNgmdtuUpLYaQ7KD1t79+QNwuWtQOOHO/eQJ2/LCwO6cSVfxa6sM560r6qOtXraJugq0sCjOY8mNcwo7toY8vtf8yHa1an4L8CSm0SkH0h2EaBE0SE+Vfmb0T0RD/5f2i0Ni8Vn9QLe2P32CRT8VWhFNs+rqj1VwpspDjwa/X+R44RBgLmf61bZQpW5bKauLTR/JrXejppkSXRRqYFDokYTbAVOZbTacwqj7b4D+H6tUb8PaG6wMu5GLe1/rLwREn49cWA3LLX/U7wcUqbIW9jYYFRjt4Cs4YFZXIsaqhAcBcitajFXiZsOdYgHnIHNR4C86oH/dM5UjVSXcpuAw8xcJ4AAEaF3EE3C+bfWZZBHbmfdF1mDbezuTKGynzsQs6i9tlOlrgL9KVsj4YThPqk8Mfa3UOHSG6dOKVqxECPb5voSzKQvRyrzPVjONgmuHf4r/7E8ur1hsXuZGnaVphWTG+fPX4Sdiuo2kn1pOCLt1C8aXqsDpKcnzBjm1yeV8m7jIOBDhPm0mrGHjiCix7NqgxUPuAwLC1zIAXIKyAIpJzig+WlQC6gFu/7zlm0qrowxLImX4seb4rWp90OFcutek0NEVy1BO2LNn4TspaeTWkqD9vR4yQ=

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ similar to tools like apt, dnf or [brew](http://brew.sh).
 
 ### Installation
 
+> :warning: **Warning** :warning: **Kubectl v1.12 completely changes the plugin
+> model in a breaking way and it's not compatible with krew yet**
+> ([#33](https://github.com/GoogleContainerTools/krew/issues/33)). Therefore,
+> krew will make breaking changes in v0.2. If you're installing krew v0.1.0 to
+> try out, make sure you have kubectl v1.11.
+
 For macOS and Linux:
 
 - Make sure that git is installed.

--- a/cmd/krew/cmd/root.go
+++ b/cmd/krew/cmd/root.go
@@ -39,6 +39,14 @@ var rootCmd = &cobra.Command{
 You can invoke krew through kubectl with: "kubectl plugin [krew] option..."`,
 	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 		bindEnvironmentVariables(viper.GetViper(), cmd)
+
+		glog.Warning("Upcoming breaking change notice:\n" +
+			"+++++++++++++++++++++++++++++++++++++++++++++++++\n" +
+			"WARNING: krew will soon introduce breaking changes to move to\n" +
+			"the new plugin system introduced in kubectl v1.12 and it will stop\n" +
+			"working until you uninstall and reinstall krew v0.2.0.\n" +
+			"This version of krew is compatible only with kubectl v1.11 or lower.\n" +
+			"+++++++++++++++++++++++++++++++++++++++++++++++++")
 	},
 }
 

--- a/cmd/krew/cmd/root.go
+++ b/cmd/krew/cmd/root.go
@@ -62,8 +62,8 @@ func init() {
 	// Required by glog
 	flag.Parse()
 
-	paths = environment.MustGetKrewPathsFromEnvs(os.Environ())
-	if err := ensureDirs(paths.Base, paths.Download, paths.Install); err != nil {
+	paths = environment.MustGetKrewPaths()
+	if err := ensureDirs(paths.Base, paths.Download, paths.Install, paths.Bin); err != nil {
 		glog.Fatal(err)
 	}
 

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -20,11 +20,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/GoogleContainerTools/krew/pkg/pathutil"
 	"k8s.io/client-go/util/homedir"
+
+	"github.com/GoogleContainerTools/krew/pkg/pathutil"
 )
 
-// KrewPaths contains all important enviroment paths
+// KrewPaths contains all important environment paths
 type KrewPaths struct {
 	// Base is the path of the krew root.
 	// The default path is ~/.kube/plugins/krew
@@ -41,6 +42,10 @@ type KrewPaths struct {
 	// Download is a directory where plugins will be temporarily downloaded to.
 	// This is currently a path in os.TempDir()
 	Download string
+
+	// Bin is the path krew links all plugin binaries to.
+	// This path has to be added to the $PATH.
+	Bin string
 }
 
 func parseEnvs(environ []string) map[string]string {
@@ -52,9 +57,9 @@ func parseEnvs(environ []string) map[string]string {
 	return flags
 }
 
-// MustGetKrewPathsFromEnvs returns ensured index paths for krew.
-func MustGetKrewPathsFromEnvs(envs []string) KrewPaths {
-	base := filepath.Join(getKubectlPluginsPath(envs), "krew")
+// MustGetKrewPaths returns ensured index paths for krew.
+func MustGetKrewPaths() KrewPaths {
+	base := filepath.Join(homedir.HomeDir(), ".kube", "plugins", "krew")
 	base, err := filepath.Abs(base)
 	if err != nil {
 		panic(fmt.Errorf("cannot get current pwd err: %v", err))
@@ -65,33 +70,13 @@ func MustGetKrewPathsFromEnvs(envs []string) KrewPaths {
 		Index:    filepath.Join(base, "index"),
 		Install:  filepath.Join(base, "store"),
 		Download: filepath.Join(os.TempDir(), "krew"),
+		Bin:      filepath.Join(base, "bin"),
 	}
-}
-
-func getKubectlPluginsPath(envs []string) string {
-	envvars := parseEnvs(envs)
-
-	// Look for "${KUBECTL_PLUGINS_PATH}"
-	if path, ok := envvars["KUBECTL_PLUGINS_PATH"]; ok && path != "" {
-		return path
-	}
-
-	// TODO(lbb): make os call testable! (dep injection)
-	// Look for "${XDG_DATA_DIRS}/kubectl/plugins"
-	if path := envvars["XDG_DATA_DIRS"]; path != "" {
-		fullPath := filepath.Join(path, "kubectl", "plugins")
-		stat, err := os.Stat(fullPath)
-		if err == nil && stat.IsDir() {
-			return fullPath
-		}
-	}
-
-	// Golang does no '~' expansion
-	return filepath.Join(homedir.HomeDir(), ".kube", "plugins")
 }
 
 // GetExecutedVersion returns the currently executed version. If krew is
 // not executed as an plugin it will return a nil error and an empty string.
+// TODO(lbb): Breaks, refactor.
 func GetExecutedVersion(paths KrewPaths, cmdArgs []string) (string, bool, error) {
 	currentBinaryPath, err := filepath.Abs(cmdArgs[0])
 	if err != nil {

--- a/pkg/environment/environment_test.go
+++ b/pkg/environment/environment_test.go
@@ -18,8 +18,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
-
-	"k8s.io/client-go/util/homedir"
 )
 
 func Test_parseEnvs(t *testing.T) {
@@ -62,47 +60,6 @@ func Test_parseEnvs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := parseEnvs(tt.args.environ); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("parseEnvs() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_getKubectlPluginsPath(t *testing.T) {
-	type args struct {
-		envs []string
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{
-			name: "default path",
-			args: args{
-				envs: []string{"HOME=~"},
-			},
-			want: filepath.Join(homedir.HomeDir(), ".kube", "plugins"),
-		},
-		{
-			name: "manual plugin path",
-			args: args{
-				envs: []string{"KUBECTL_PLUGINS_PATH=/foobar", "HOME=~"},
-			},
-			want: "/foobar",
-		},
-		{
-			name: "no further xdg",
-			args: args{
-				envs: []string{"XDG_DATA_DIRS=/", "HOME=~"},
-			},
-			want: filepath.Join(homedir.HomeDir(), ".kube", "plugins"),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := getKubectlPluginsPath(tt.args.envs); got != tt.want {
-				t.Errorf("getKubectlPluginsPath() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/index/indexscanner/testdata/testindex/plugins/bar.yaml
+++ b/pkg/index/indexscanner/testdata/testindex/plugins/bar.yaml
@@ -21,8 +21,10 @@ spec:
   - files:
     - from: "*"
     head: https://example.com
+    bin: kubectl-bar
   - files:
     - from: "*"
     uri: https://example.com
     sha256: alsoSet
+    bin: kubectl-bar
   shortDescription: "exists"

--- a/pkg/index/indexscanner/testdata/testindex/plugins/foo.yaml
+++ b/pkg/index/indexscanner/testdata/testindex/plugins/foo.yaml
@@ -21,12 +21,14 @@ spec:
   - files:
     - from: "*"
     head: https://example.com
+    bin: kubectl-foo
     selector:
       matchExpressions:
       - {key: os, operator: In, values: [macos, linux]}
   - files:
     - from: "*"
     head: https://example.com
+    bin: kubectl-foo
     selector:
       matchLabels:
         os: "windows"

--- a/pkg/index/types.go
+++ b/pkg/index/types.go
@@ -45,6 +45,11 @@ type Platform struct {
 
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 	Files    []FileOperation       `json:"files"`
+
+	// Bin specifies the path to the plugin executable.
+	// The path is relative to the root of the installation folder.
+	// The binary will be linked after all FileOperations are executed.
+	Bin string `json:"bin"`
 }
 
 // FileOperation TODO(lbb)

--- a/pkg/index/validate.go
+++ b/pkg/index/validate.go
@@ -69,6 +69,12 @@ func (p Platform) Validate() error {
 	if p.Head == "" && p.URI == "" {
 		return fmt.Errorf("head or URI have to be set")
 	}
+	if p.Bin == "" {
+		return fmt.Errorf("bin has to be set")
+	}
+	if !strings.HasPrefix(p.Bin, "kubectl-") {
+		return fmt.Errorf("the plugin executeable needs to have the 'kubectl-' prefix")
+	}
 	if len(p.Files) == 0 {
 		return fmt.Errorf("can't have a plugin without specifying file operations")
 	}

--- a/pkg/index/validate_test.go
+++ b/pkg/index/validate_test.go
@@ -97,6 +97,7 @@ func TestPlugin_Validate(t *testing.T) {
 						Sha256:   "",
 						Selector: nil,
 						Files:    []FileOperation{{"", ""}},
+						Bin:      "kubectl-foo",
 					}},
 				},
 			},
@@ -120,6 +121,7 @@ func TestPlugin_Validate(t *testing.T) {
 						Sha256:   "",
 						Selector: nil,
 						Files:    []FileOperation{{"", ""}},
+						Bin:      "kubectl-foo",
 					}},
 				},
 			},
@@ -143,6 +145,7 @@ func TestPlugin_Validate(t *testing.T) {
 						Sha256:   "",
 						Selector: nil,
 						Files:    []FileOperation{},
+						Bin:      "kubectl-foo",
 					}},
 				},
 			},
@@ -166,6 +169,7 @@ func TestPlugin_Validate(t *testing.T) {
 						Sha256:   "",
 						Selector: nil,
 						Files:    []FileOperation{{"", ""}},
+						Bin:      "kubectl-foo",
 					}},
 				},
 			},
@@ -189,6 +193,7 @@ func TestPlugin_Validate(t *testing.T) {
 						Sha256:   "",
 						Selector: nil,
 						Files:    []FileOperation{{"", ""}},
+						Bin:      "kubectl-foo",
 					}},
 				},
 			},
@@ -219,6 +224,7 @@ func TestPlatform_Validate(t *testing.T) {
 		Sha256   string
 		Selector *metav1.LabelSelector
 		Files    []FileOperation
+		Bin      string
 	}
 	tests := []struct {
 		name    string
@@ -233,6 +239,7 @@ func TestPlatform_Validate(t *testing.T) {
 				Sha256:   "",
 				Selector: nil,
 				Files:    []FileOperation{{"", ""}},
+				Bin:      "kubectl-foo",
 			},
 			wantErr: false,
 		},
@@ -244,6 +251,7 @@ func TestPlatform_Validate(t *testing.T) {
 				Sha256:   "",
 				Selector: nil,
 				Files:    []FileOperation{{"", ""}},
+				Bin:      "kubectl-foo",
 			},
 			wantErr: true,
 		},
@@ -255,6 +263,7 @@ func TestPlatform_Validate(t *testing.T) {
 				Sha256:   "deadbeef",
 				Selector: nil,
 				Files:    []FileOperation{{"", ""}},
+				Bin:      "kubectl-foo",
 			},
 			wantErr: true,
 		},
@@ -266,6 +275,7 @@ func TestPlatform_Validate(t *testing.T) {
 				Sha256:   "",
 				Selector: nil,
 				Files:    []FileOperation{{"", ""}},
+				Bin:      "kubectl-foo",
 			},
 			wantErr: true,
 		},
@@ -277,6 +287,31 @@ func TestPlatform_Validate(t *testing.T) {
 				Sha256:   "",
 				Selector: nil,
 				Files:    []FileOperation{},
+				Bin:      "kubectl-foo",
+			},
+			wantErr: true,
+		},
+		{
+			name: "no bin",
+			fields: fields{
+				Head:     "http://example.com",
+				URI:      "",
+				Sha256:   "",
+				Selector: nil,
+				Files:    []FileOperation{{"", ""}},
+				Bin:      "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "wrong bin prefix",
+			fields: fields{
+				Head:     "http://example.com",
+				URI:      "",
+				Sha256:   "",
+				Selector: nil,
+				Files:    []FileOperation{{"", ""}},
+				Bin:      "foo",
 			},
 			wantErr: true,
 		},
@@ -289,6 +324,7 @@ func TestPlatform_Validate(t *testing.T) {
 				Sha256:   tt.fields.Sha256,
 				Selector: tt.fields.Selector,
 				Files:    tt.fields.Files,
+				Bin:      tt.fields.Bin,
 			}
 			if err := p.Validate(); (err != nil) != tt.wantErr {
 				t.Errorf("Platform.Validate() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/installation/move.go
+++ b/pkg/installation/move.go
@@ -41,11 +41,11 @@ func findMoveTargets(fromDir, toDir string, fo index.FileOperation) ([]move, err
 		return nil, fmt.Errorf("could not get the relative path for the move src, err: %v", err)
 	}
 
-	glog.V(4).Infoln("Trying to move single file directly from=%q to=%q with file operation=%+v", fromDir, toDir, fo)
+	glog.V(4).Infof("Trying to move single file directly from=%q to=%q with file operation=%+v", fromDir, toDir, fo)
 	if m, ok, err := getDirectMove(fromDir, toDir, fo); err != nil {
 		return nil, fmt.Errorf("failed to detect single move operation, err: %v", err)
 	} else if ok {
-		glog.V(3).Infof("Detected single move from file operation", fo)
+		glog.V(3).Infof("Detected single move from file operation=%+v", fo)
 		return []move{m}, nil
 	}
 


### PR DESCRIPTION
Looks like this:

	$ out/build/krew-darwin update
	W0912 12:58:28.998960    8579 root.go:43] Upcoming breaking change notice:
	+++++++++++++++++++++++++++++++++++++++++++++++++
	WARNING: krew will soon introduce breaking changes to move to
	the new plugin system introduced in kubectl v1.12 and it will stop
	working until it a newer version of krew is reinstalled.
    This version of krew is compatible only with kubectl v1.11.
	+++++++++++++++++++++++++++++++++++++++++++++++++
	Updated index