### PR TITLE
pkg/kubectl: check version of kubectl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
 - hack/gofmt.sh
 - hack/gometalinter.sh
 - go test -v -coverprofile=coverage.txt -covermode=atomic ./...
-- hack/build-cross-releases.sh
+- KREW_DISABLE_KUBECTL_VERSION_CHECK=1 hack/build-cross-releases.sh
 after_success:
 - bash <(curl -s https://codecov.io/bash)
 deploy:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,12 @@
 
 
 [[projects]]
+  name = "github.com/coreos/go-semver"
+  packages = ["semver"]
+  revision = "8ab6407b697782a06568d4b7f1db25550ec2e4c6"
+  version = "v0.2.0"
+
+[[projects]]
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
@@ -214,6 +220,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c3ca012d72b2d2328374c7f1711577522c894ad81ad72d7023980b35a4d1bfc0"
+  inputs-digest = "e3c6755d158b3c3c45a5906cccff6ee9502c26e79e48b111931efa52356bb9e7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,3 +46,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  name = "github.com/coreos/go-semver"
+  version = "0.2.0"

--- a/cmd/krew/cmd/root.go
+++ b/cmd/krew/cmd/root.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/GoogleContainerTools/krew/pkg/kubectl"
+
 	"github.com/GoogleContainerTools/krew/pkg/environment"
 	"github.com/GoogleContainerTools/krew/pkg/gitutil"
 
@@ -39,6 +41,20 @@ var rootCmd = &cobra.Command{
 You can invoke krew through kubectl with: "kubectl plugin [krew] option..."`,
 	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 		bindEnvironmentVariables(viper.GetViper(), cmd)
+
+		// detect kubectl version to prevent running krew standalone with older
+		// versions of kubectl.
+		// TODO(ahmetb): this may not be necessary after most users are on 1.12
+		glog.V(4).Infof("checking kubectl version")
+		ok, err := kubectl.IsSupportedVersion()
+		if err != nil {
+			glog.Fatalf("error checking kubectl version: %+v", err)
+		}
+		if !ok && os.Getenv("KREW_DISABLE_KUBECTL_VERSION_CHECK") == "" {
+			glog.Fatal("You are running on an unsupported version of \"kubectl\"." +
+				" This version of krew requires minimum kubectl 1.12.0.")
+		}
+		glog.V(4).Infof("checked kubectl version")
 	},
 }
 

--- a/pkg/kubectl/kubectl_version.go
+++ b/pkg/kubectl/kubectl_version.go
@@ -1,0 +1,66 @@
+package kubectl
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/coreos/go-semver/semver"
+)
+
+var (
+	minKubectl      = semver.New("1.12.0-alpha.0")
+	versionProvider = execKubectlVersion
+)
+
+func execKubectlVersion() (string, error) {
+	cmd := exec.Command("kubectl", "version", "--client", "--output=json")
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to execute kubectl version. error=%v, out=%v", err, string(b))
+	}
+	return string(b), nil
+}
+
+func parseKubectlVersion(s string) (*semver.Version, error) {
+	v := struct {
+		ClientVersion struct {
+			GitVersion string `json:"gitVersion"`
+		} `json:"clientVersion"`
+	}{}
+
+	if err := json.Unmarshal([]byte(s), &v); err != nil {
+		return nil, fmt.Errorf("error parsing kubectl version: %+v", err)
+	}
+	if v.ClientVersion.GitVersion == "" {
+		return nil, fmt.Errorf("could not locate kubectl client version in: %s", s)
+	}
+	ver, err := semver.NewVersion(strings.TrimPrefix(v.ClientVersion.GitVersion, "v"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse semver string=%q error=%q", v.ClientVersion.GitVersion, err)
+	}
+	return ver, nil
+}
+
+func getKubectlVersion() (*semver.Version, error) {
+	out, err := versionProvider()
+	if err != nil {
+		return nil, fmt.Errorf("could not detect kubectl version: %+v", err)
+	}
+	v, err := parseKubectlVersion(out)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing kubectl version: %+v", err)
+	}
+	return v, nil
+}
+
+// IsSupportedVersion determines if kubectl version satisfies the minimum
+// verison requirements.
+func IsSupportedVersion() (bool, error) {
+	v, err := getKubectlVersion()
+	if err != nil {
+		return false, fmt.Errorf("version check error: %+v", err)
+	}
+	return !v.LessThan(*minKubectl), nil
+}

--- a/pkg/kubectl/kubectl_version_test.go
+++ b/pkg/kubectl/kubectl_version_test.go
@@ -1,0 +1,159 @@
+package kubectl
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/coreos/go-semver/semver"
+)
+
+func mockVersionJSON(ver string) string {
+	return fmt.Sprintf(`{"clientVersion": {"gitVersion": %q}}`, ver)
+}
+
+func mockVersionCmd(ver string) func() (string, error) {
+	return func() (string, error) {
+		return mockVersionJSON(ver), nil
+	}
+}
+
+func badJSONCmd() func() (string, error) {
+	return func() (string, error) {
+		return `{"clientVersion": {"gitVersion": "v1.11.9"}`, nil
+	}
+}
+
+func failingVersionCmd() func() (string, error) {
+	return func() (string, error) {
+		return "", errors.New("mock failure")
+	}
+}
+
+func Test_parseKubectlVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    string
+		want    *semver.Version
+		wantErr bool
+	}{
+		{name: "valid version with suffix",
+			args: mockVersionJSON("v2.0.01"),
+			want: semver.New("2.0.1")},
+		{name: "valid version with suffix",
+			args: mockVersionJSON("v01.11.0-beta.1"),
+			want: semver.New("1.11.0-beta.1")},
+		{name: "json error",
+			args:    `{"clientVersion" {"gitCommit":"1.1.1"}}`,
+			wantErr: true},
+		{name: "missing field",
+			args:    `{"clientVersion": {"compiler":"gc"}}`,
+			wantErr: true},
+		{name: "invalid version string",
+			args:    mockVersionJSON("1.0.a"),
+			wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseKubectlVersion(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseKubectlVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseKubectlVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getKubectlVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		versionExec func() (string, error)
+		want        *semver.Version
+		wantErr     bool
+	}{
+		{name: "exec error (mock failure)",
+			versionExec: failingVersionCmd(),
+			wantErr:     true},
+		{name: "parse error (bad json)",
+			versionExec: badJSONCmd(),
+			wantErr:     true},
+		{name: "parse error (bad version)",
+			versionExec: mockVersionCmd("v1.a"),
+			wantErr:     true},
+		{name: "valid",
+			versionExec: mockVersionCmd("v1.11.1-alpha.3"),
+			want:        semver.New("1.11.1-alpha.3")},
+	}
+
+	orig := versionProvider
+	defer func() { versionProvider = orig }()
+
+	for _, tt := range tests {
+		versionProvider = tt.versionExec
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getKubectlVersion()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getKubectlVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getKubectlVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsSupportedVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		versionExecutor func() (string, error)
+		want            bool
+		wantErr         bool
+	}{
+		{name: "valid (equals)",
+			versionExecutor: mockVersionCmd("v1.12.0-alpha.0"),
+			want:            true},
+		{name: "valid (with alpha)",
+			versionExecutor: mockVersionCmd("v1.12.0-alpha.0"),
+			want:            true},
+		{name: "valid (with beta)",
+			versionExecutor: mockVersionCmd("v1.12.0-beta.1"),
+			want:            true},
+		{name: "valid (greater) stable",
+			versionExecutor: mockVersionCmd("v1.12.0"),
+			want:            true},
+		{name: "valid (greater) patch",
+			versionExecutor: mockVersionCmd("v1.12.1"),
+			want:            true},
+		{name: "invalid (unsupported)",
+			versionExecutor: mockVersionCmd("v1.11.99999"),
+			want:            false},
+		{name: "invalid (lexicographically less)",
+			versionExecutor: mockVersionCmd("v1.12.0-aa.1"),
+			want:            false},
+		{name: "exec failure",
+			versionExecutor: failingVersionCmd(),
+			wantErr:         true}}
+
+	orig := versionProvider
+	defer func() { versionProvider = orig }()
+
+	for _, tt := range tests {
+		versionProvider = tt.versionExecutor
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IsSupportedVersion()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IsSupportedVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				vv, _ := getKubectlVersion()
+				t.Errorf("IsSupportedVersion() = %v (detected=%v) want %v", got, vv, tt.want)
+			}
+		})
+	}
+}

--- a/vendor/github.com/coreos/go-semver/LICENSE
+++ b/vendor/github.com/coreos/go-semver/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/coreos/go-semver/semver/semver.go
+++ b/vendor/github.com/coreos/go-semver/semver/semver.go
@@ -1,0 +1,268 @@
+// Copyright 2013-2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Semantic Versions http://semver.org
+package semver
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Version struct {
+	Major      int64
+	Minor      int64
+	Patch      int64
+	PreRelease PreRelease
+	Metadata   string
+}
+
+type PreRelease string
+
+func splitOff(input *string, delim string) (val string) {
+	parts := strings.SplitN(*input, delim, 2)
+
+	if len(parts) == 2 {
+		*input = parts[0]
+		val = parts[1]
+	}
+
+	return val
+}
+
+func New(version string) *Version {
+	return Must(NewVersion(version))
+}
+
+func NewVersion(version string) (*Version, error) {
+	v := Version{}
+
+	if err := v.Set(version); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// Must is a helper for wrapping NewVersion and will panic if err is not nil.
+func Must(v *Version, err error) *Version {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// Set parses and updates v from the given version string. Implements flag.Value
+func (v *Version) Set(version string) error {
+	metadata := splitOff(&version, "+")
+	preRelease := PreRelease(splitOff(&version, "-"))
+	dotParts := strings.SplitN(version, ".", 3)
+
+	if len(dotParts) != 3 {
+		return fmt.Errorf("%s is not in dotted-tri format", version)
+	}
+
+	parsed := make([]int64, 3, 3)
+
+	for i, v := range dotParts[:3] {
+		val, err := strconv.ParseInt(v, 10, 64)
+		parsed[i] = val
+		if err != nil {
+			return err
+		}
+	}
+
+	v.Metadata = metadata
+	v.PreRelease = preRelease
+	v.Major = parsed[0]
+	v.Minor = parsed[1]
+	v.Patch = parsed[2]
+	return nil
+}
+
+func (v Version) String() string {
+	var buffer bytes.Buffer
+
+	fmt.Fprintf(&buffer, "%d.%d.%d", v.Major, v.Minor, v.Patch)
+
+	if v.PreRelease != "" {
+		fmt.Fprintf(&buffer, "-%s", v.PreRelease)
+	}
+
+	if v.Metadata != "" {
+		fmt.Fprintf(&buffer, "+%s", v.Metadata)
+	}
+
+	return buffer.String()
+}
+
+func (v *Version) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var data string
+	if err := unmarshal(&data); err != nil {
+		return err
+	}
+	return v.Set(data)
+}
+
+func (v Version) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + v.String() + `"`), nil
+}
+
+func (v *Version) UnmarshalJSON(data []byte) error {
+	l := len(data)
+	if l == 0 || string(data) == `""` {
+		return nil
+	}
+	if l < 2 || data[0] != '"' || data[l-1] != '"' {
+		return errors.New("invalid semver string")
+	}
+	return v.Set(string(data[1 : l-1]))
+}
+
+// Compare tests if v is less than, equal to, or greater than versionB,
+// returning -1, 0, or +1 respectively.
+func (v Version) Compare(versionB Version) int {
+	if cmp := recursiveCompare(v.Slice(), versionB.Slice()); cmp != 0 {
+		return cmp
+	}
+	return preReleaseCompare(v, versionB)
+}
+
+// Equal tests if v is equal to versionB.
+func (v Version) Equal(versionB Version) bool {
+	return v.Compare(versionB) == 0
+}
+
+// LessThan tests if v is less than versionB.
+func (v Version) LessThan(versionB Version) bool {
+	return v.Compare(versionB) < 0
+}
+
+// Slice converts the comparable parts of the semver into a slice of integers.
+func (v Version) Slice() []int64 {
+	return []int64{v.Major, v.Minor, v.Patch}
+}
+
+func (p PreRelease) Slice() []string {
+	preRelease := string(p)
+	return strings.Split(preRelease, ".")
+}
+
+func preReleaseCompare(versionA Version, versionB Version) int {
+	a := versionA.PreRelease
+	b := versionB.PreRelease
+
+	/* Handle the case where if two versions are otherwise equal it is the
+	 * one without a PreRelease that is greater */
+	if len(a) == 0 && (len(b) > 0) {
+		return 1
+	} else if len(b) == 0 && (len(a) > 0) {
+		return -1
+	}
+
+	// If there is a prerelease, check and compare each part.
+	return recursivePreReleaseCompare(a.Slice(), b.Slice())
+}
+
+func recursiveCompare(versionA []int64, versionB []int64) int {
+	if len(versionA) == 0 {
+		return 0
+	}
+
+	a := versionA[0]
+	b := versionB[0]
+
+	if a > b {
+		return 1
+	} else if a < b {
+		return -1
+	}
+
+	return recursiveCompare(versionA[1:], versionB[1:])
+}
+
+func recursivePreReleaseCompare(versionA []string, versionB []string) int {
+	// A larger set of pre-release fields has a higher precedence than a smaller set,
+	// if all of the preceding identifiers are equal.
+	if len(versionA) == 0 {
+		if len(versionB) > 0 {
+			return -1
+		}
+		return 0
+	} else if len(versionB) == 0 {
+		// We're longer than versionB so return 1.
+		return 1
+	}
+
+	a := versionA[0]
+	b := versionB[0]
+
+	aInt := false
+	bInt := false
+
+	aI, err := strconv.Atoi(versionA[0])
+	if err == nil {
+		aInt = true
+	}
+
+	bI, err := strconv.Atoi(versionB[0])
+	if err == nil {
+		bInt = true
+	}
+
+	// Handle Integer Comparison
+	if aInt && bInt {
+		if aI > bI {
+			return 1
+		} else if aI < bI {
+			return -1
+		}
+	}
+
+	// Handle String Comparison
+	if a > b {
+		return 1
+	} else if a < b {
+		return -1
+	}
+
+	return recursivePreReleaseCompare(versionA[1:], versionB[1:])
+}
+
+// BumpMajor increments the Major field by 1 and resets all other fields to their default values
+func (v *Version) BumpMajor() {
+	v.Major += 1
+	v.Minor = 0
+	v.Patch = 0
+	v.PreRelease = PreRelease("")
+	v.Metadata = ""
+}
+
+// BumpMinor increments the Minor field by 1 and resets all other fields to their default values
+func (v *Version) BumpMinor() {
+	v.Minor += 1
+	v.Patch = 0
+	v.PreRelease = PreRelease("")
+	v.Metadata = ""
+}
+
+// BumpPatch increments the Patch field by 1 and resets all other fields to their default values
+func (v *Version) BumpPatch() {
+	v.Patch += 1
+	v.PreRelease = PreRelease("")
+	v.Metadata = ""
+}

--- a/vendor/github.com/coreos/go-semver/semver/sort.go
+++ b/vendor/github.com/coreos/go-semver/semver/sort.go
@@ -1,0 +1,38 @@
+// Copyright 2013-2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semver
+
+import (
+	"sort"
+)
+
+type Versions []*Version
+
+func (s Versions) Len() int {
+	return len(s)
+}
+
+func (s Versions) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s Versions) Less(i, j int) bool {
+	return s[i].LessThan(*s[j])
+}
+
+// Sort sorts the given slice of Version
+func Sort(versions []*Version) {
+	sort.Sort(Versions(versions))
+}


### PR DESCRIPTION
If someone tries to execute krew binary standalone with kubectl <1.12, adding
a failure.

I'm not entirely sure if it's a valid use case. The only encounter of this
could be when someone installs krew, and directly tries to invoke the binary
(as krew 0.2 won't work on kubectl 1.11 or older).

Probably harmless for now (also added a KREW_DISABLE_KUBECTL_VERSION_CHECK
escape hatch for dev/build purposes). We can remove this pkg and check soon.
Currently adds ~100 ms to each krew cmd.