### PR TITLE
pkg/installation: prevent empty glob operations

### DIFF
--- a/pkg/installation/move.go
+++ b/pkg/installation/move.go
@@ -41,11 +41,11 @@ func findMoveTargets(fromDir, toDir string, fo index.FileOperation) ([]move, err
 		return nil, fmt.Errorf("could not get the relative path for the move src, err: %v", err)
 	}
 
-	glog.V(4).Infof("Trying to move single file directly from=%q to=%q with file operation=%+v", fromDir, toDir, fo)
+	glog.V(4).Infof("Trying to move single file directly from=%q to=%q with file operation=%#v", fromDir, toDir, fo)
 	if m, ok, err := getDirectMove(fromDir, toDir, fo); err != nil {
 		return nil, fmt.Errorf("failed to detect single move operation, err: %v", err)
 	} else if ok {
-		glog.V(3).Infof("Detected single move from file operation=%+v", fo)
+		glog.V(3).Infof("Detected single move from file operation=%#v", fo)
 		return []move{m}, nil
 	}
 
@@ -59,6 +59,9 @@ func findMoveTargets(fromDir, toDir string, fo index.FileOperation) ([]move, err
 	if err != nil {
 		return nil, fmt.Errorf("could not get files using a glob string, err: %v", err)
 	}
+	if len(gl) == 0 {
+		return nil, fmt.Errorf("no files in the plugin archive matched the glob pattern=%s", fo.From)
+	}
 
 	var moves []move
 	for _, v := range gl {
@@ -70,6 +73,7 @@ func findMoveTargets(fromDir, toDir string, fo index.FileOperation) ([]move, err
 		}
 		moves = append(moves, m)
 	}
+	glog.V(4).Infoln("Move operations are complete")
 	return moves, nil
 }
 
@@ -119,7 +123,7 @@ func isMoveAllowed(fromBase, toBase string, m move) bool {
 }
 
 func moveFiles(fromDir, toDir string, fo index.FileOperation) error {
-	glog.V(4).Infof("Finding move targets from %q to %q with file operation=%v", fromDir, toDir, fo)
+	glog.V(4).Infof("Finding move targets from %q to %q with file operation=%#v", fromDir, toDir, fo)
 	moves, err := findMoveTargets(fromDir, toDir, fo)
 	if err != nil {
 		return fmt.Errorf("could not find move targets, err: %v", err)

--- a/pkg/installation/move_test.go
+++ b/pkg/installation/move_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/GoogleContainerTools/krew/pkg/index"
 )
 
-func Test_moveToInstallAtomic(t *testing.T) {
+func Test_findMoveTargets(t *testing.T) {
 	type args struct {
 		fromDir string
 		toDir   string
@@ -67,6 +67,18 @@ func Test_moveToInstallAtomic(t *testing.T) {
 				to:   filepath.Join(testdataPath(t), "testdir_B", "foo"),
 			}},
 			wantErr: false,
+		},
+		{
+			name: "glob not matching any files",
+			args: args{
+				fromDir: filepath.Join(testdataPath(t), "testdir_A"),
+				toDir:   filepath.Join(testdataPath(t), "testdir_B"),
+				fo: index.FileOperation{
+					From: "./nonexisting-*",
+					To:   "unused",
+				},
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
- detect empty globs
    - may indicate typo
    - may indicate changes in the archive structure but plugin manifest is out
      of date
- fix test name
- use %#v for printing FileOperation in verbose logs