### PR TITLE
Convert dashes in plugin names to underscores

### DIFF
--- a/pkg/installation/install_test.go
+++ b/pkg/installation/install_test.go
@@ -123,3 +123,24 @@ func Test_createOrUpdateLink(t *testing.T) {
 		})
 	}
 }
+
+func Test_pluginNameToBin(t *testing.T) {
+
+	tests := []struct {
+		name      string
+		isWindows bool
+		want      string
+	}{
+		{"foo", false, "kubectl-foo"},
+		{"foo-bar", false, "kubectl-foo_bar"},
+		{"foo", true, "kubectl-foo.exe"},
+		{"foo-bar", true, "kubectl-foo_bar.exe"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pluginNameToBin(tt.name, tt.isWindows); got != tt.want {
+				t.Errorf("pluginNameToBin(%v, %v) = %v; want %v", tt.name, tt.isWindows, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/installation/util.go
+++ b/pkg/installation/util.go
@@ -59,7 +59,7 @@ func findInstalledPluginVersion(installPath, binDir, pluginName string) (name st
 		return "", false, fmt.Errorf("the plugin name %q is not allowed", pluginName)
 	}
 	glog.V(3).Infof("Searching for installed versions of %s in %q", pluginName, binDir)
-	link, err := os.Readlink(filepath.Join(binDir, pluginNameToBin(pluginName)))
+	link, err := os.Readlink(filepath.Join(binDir, pluginNameToBin(pluginName, isWindows())))
 	if os.IsNotExist(err) {
 		return "", false, nil
 	} else if err != nil {


### PR DESCRIPTION
For dashes to be preserved in a plugin's name, its executable name must convert
dashes to underscores.

For example a plugin named "foo-bar" would today be linked as:

    kubectl-foo-bar

therefore, it can only be invoked as:

    kubectl foo bar

However, linking the same plugin as:

    kubectl-foo_bar

allows plugin to be called as:

    kubectl foo-bar
    kubectl foo_bar

- convert OS detection pluginNameToBin() to explicit input for testability
- test pluginNameToBin().

Fixes #59.