### PR TITLE
pkg/env: add tests for ResolveLink and rename

### DIFF
--- a/cmd/krew/cmd/root.go
+++ b/cmd/krew/cmd/root.go
@@ -65,7 +65,7 @@ func init() {
 	if err != nil {
 		glog.Errorf("failed to get the own executable path")
 	}
-	if krewVersion, ok, err := environment.GetExecutedVersion(paths.Install, selfPath, environment.ResolveSymlink); err != nil {
+	if krewVersion, ok, err := environment.GetExecutedVersion(paths.Install, selfPath, environment.Realpath); err != nil {
 		glog.Fatal(fmt.Errorf("failed to find current krew version, err: %v", err))
 	} else if ok {
 		krewExecutedVersion = krewVersion


### PR DESCRIPTION
- Changing ResolveLink to Realpath as it sounds more like a readlink/realpath
  operation (e.g. it works on directories and regular files).
- Add unit tests.
- Refusing to run on _relative_ symlinks (add error).
- Use filepath.Clean.