### PR TITLE
pkg/env: allow base path override with KREW_ROOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ krew is the missing kubectl plugin manager.
 ## What is krew?
 
 krew is a tool that makes it easy to install
-[kubectl plugins](https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/). 
+[kubectl plugins](https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/).
 krew helps you discover plugins, install and manage them on your machine. It is
 similar to tools like apt, dnf or [brew](http://brew.sh).
 
@@ -19,17 +19,25 @@ similar to tools like apt, dnf or [brew](http://brew.sh).
 
 For macOS and Linux:
 
-- Make sure that git is installed.
-- Paste this command to your terminal:
+1. Make sure that `git` is installed.
+2. Run this command in your terminal to download and install `krew`:
 
-```bash
-(
-  set -x; cd "$(mktemp -d)" &&
-  curl -fsSLO "https://github.com/GoogleContainerTools/krew/releases/download/v0.1.0-alpha.1/krew.zip" &&
-  unzip krew.zip &&
-  "./out/build/krew-$(uname | tr '[:upper:]' '[:lower:]')" install krew
-)
-```
+    ```bash
+    (
+      set -x; cd "$(mktemp -d)" &&
+      curl -fsSLO "https://github.com/GoogleContainerTools/krew/releases/download/v0.1.0-alpha.1/krew.zip" &&
+      unzip krew.zip &&
+      "./out/build/krew-$(uname | tr '[:upper:]' '[:lower:]')" install krew
+    )
+    ```
+3. Add `$HOME/.krew/bin` directory to your PATH environment variable. To do
+   this, update your `.bashrc` or `.zshrc` file and append the following line:
+
+     ```sh
+     export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
+     ```
+
+   and restart your shell.
 
 Windows:
 
@@ -38,10 +46,13 @@ Windows:
 3. Unzip the file
 4. Launch a command-line window in the extracted directory
 5. Run: ./out/build/krew-windows.exe install krew
+6. Add `%USERPROFILE%\.krew\bin` to your PATH environment variable
+   ([how?](https://java.com/en/download/help/path.xml))
 
-To verify the installation run `kubectl plugin`.
-You should see new subcommands.
-Run `kubectl plugin list` to see all installed plugins.
+### Verifying installation
+
+Run `kubectl plugin list` command to see installed plugins. This command should
+list `kubectl-krew`.
 
 ### Finding plugins
 

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/golang/glog"
 	"k8s.io/client-go/util/homedir"
 
 	"github.com/GoogleContainerTools/krew/pkg/pathutil"
@@ -30,13 +31,18 @@ type Paths struct {
 	tmp  string
 }
 
-// MustGetKrewPaths returns the inferred paths for krew. By default, it is
-// $HOME/.krew.
+// MustGetKrewPaths returns the inferred paths for krew. By default, it assumes
+// $HOME/.krew as the base path, but can be overriden via KREW_ROOT environment
+// variable.
 func MustGetKrewPaths() Paths {
 	base := filepath.Join(homedir.HomeDir(), ".krew")
+	if fromEnv := os.Getenv("KREW_ROOT"); fromEnv != "" {
+		base = fromEnv
+		glog.V(4).Infof("using environment override KREW_ROOT=%s", fromEnv)
+	}
 	base, err := filepath.Abs(base)
 	if err != nil {
-		panic(fmt.Errorf("cannot get current pwd err: %v", err))
+		panic(fmt.Errorf("cannot get absolute path, err: %v", err))
 	}
 	return newPaths(base)
 }

--- a/pkg/environment/environment_test.go
+++ b/pkg/environment/environment_test.go
@@ -20,21 +20,27 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"k8s.io/client-go/util/homedir"
 )
 
 func TestMustGetKrewPaths_resolvesToHomeDir(t *testing.T) {
-	home := os.Getenv("USERPROFILE")
-	if home == "" {
-		home = os.Getenv("HOME")
-	}
-	if home == "" {
-		t.Fatal("cannot determine HOME or USERPROFILE")
-	}
+	home := homedir.HomeDir()
 	expectedBase := filepath.Join(home, ".krew")
-
 	p := MustGetKrewPaths()
 	if got := p.BasePath(); got != expectedBase {
 		t.Fatalf("MustGetKrewPaths()=%s; expected=%s", got, expectedBase)
+	}
+}
+
+func TestMustGetKrewPaths_envOverride(t *testing.T) {
+	custom := filepath.FromSlash("/custom/krew/path")
+	os.Setenv("KREW_ROOT", custom)
+	defer os.Unsetenv("KREW_ROOT")
+
+	p := MustGetKrewPaths()
+	if expected, got := custom, p.BasePath(); got != expected {
+		t.Fatalf("MustGetKrewPaths()=%s; expected=%s", got, expected)
 	}
 }
 


### PR DESCRIPTION
Introduces a KREW_ROOT environment variable to allow overriding
the krew base installation directory (defaults to $HOME/.krew).

Updated installation instructions to add default path to bashrc/zshrc.

Fixes #58.