### PR TITLE
pkg/install: allow OS/arch overrides with env

### DIFF
--- a/pkg/installation/util.go
+++ b/pkg/installation/util.go
@@ -32,7 +32,23 @@ import (
 
 // GetMatchingPlatform TODO(lbb)
 func GetMatchingPlatform(i index.Plugin) (index.Platform, bool, error) {
-	return matchPlatformToSystemEnvs(i, runtime.GOOS, runtime.GOARCH)
+	os, arch := osArch()
+	glog.V(4).Infof("Using os=%s arch=%s", os, arch)
+	return matchPlatformToSystemEnvs(i, os, arch)
+}
+
+// osArch returns the OS/arch combination to be used on the current system. It
+// can be overridden by setting KREW_OS and/or KREW_ARCH environment variables.
+func osArch() (string, string) {
+	goos, goarch := runtime.GOOS, runtime.GOARCH
+	envOS, envArch := os.Getenv("KREW_OS"), os.Getenv("KREW_ARCH")
+	if envOS != "" {
+		goos = envOS
+	}
+	if envArch != "" {
+		goarch = envArch
+	}
+	return goos, goarch
 }
 
 func matchPlatformToSystemEnvs(i index.Plugin, os, arch string) (index.Platform, bool, error) {

--- a/pkg/installation/util_test.go
+++ b/pkg/installation/util_test.go
@@ -15,6 +15,7 @@
 package installation
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -24,6 +25,32 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func Test_osArch_default(t *testing.T) {
+	inOS, inArch := runtime.GOOS, runtime.GOARCH
+	outOS, outArch := osArch()
+	if inOS != outOS {
+		t.Fatalf("returned OS=%q; expected=%q", outOS, inOS)
+	}
+	if inArch != outArch {
+		t.Fatalf("returned Arch=%q; expected=%q", outArch, inArch)
+	}
+}
+func Test_osArch_override(t *testing.T) {
+	customOS, customArch := "dragons", "v1"
+	os.Setenv("KREW_OS", customOS)
+	defer os.Unsetenv("KREW_OS")
+	os.Setenv("KREW_ARCH", customArch)
+	defer os.Unsetenv("KREW_ARCH")
+
+	outOS, outArch := osArch()
+	if customOS != outOS {
+		t.Fatalf("returned OS=%q; expected=%q", outOS, customOS)
+	}
+	if customArch != outArch {
+		t.Fatalf("returned Arch=%q; expected=%q", outArch, customArch)
+	}
+}
 
 func Test_matchPlatformToSystemEnvs(t *testing.T) {
 	matchingPlatform := index.Platform{


### PR DESCRIPTION
KREW_OS and KREW_ARCH can be used to override the values inferred from the
current runtime. This makes it possible to test installation of manifests
containing multiple platform specs.

Fixes #69.