### PR TITLE
pkg/index: add manifest apiVersion check

### DIFF
--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -67,7 +67,7 @@ All plugins will be downloaded and made available to: "kubectl plugin <name>"`,
 			for _, name := range pluginNames {
 				plugin, err := indexscanner.LoadPluginFileFromFS(paths.IndexPath(), name)
 				if err != nil {
-					return errors.Wrapf(err, "failed to load plugin %q from index", name)
+					return errors.Wrapf(err, "failed to load plugin %q from the index", name)
 				}
 				install = append(install, plugin)
 			}

--- a/pkg/index/indexscanner/testdata/testindex/dontscan.yaml
+++ b/pkg/index/indexscanner/testdata/testindex/dontscan.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: plugin.krew.app/v1alpha1
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: dontscan

--- a/pkg/index/indexscanner/testdata/testindex/plugins/badplugin.yaml
+++ b/pkg/index/indexscanner/testdata/testindex/plugins/badplugin.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: plugin.krew.app/v1alpha1
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: badplugin

--- a/pkg/index/indexscanner/testdata/testindex/plugins/badplugin2.yaml
+++ b/pkg/index/indexscanner/testdata/testindex/plugins/badplugin2.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: plugin.krew.app/v1alpha1
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: badplugin

--- a/pkg/index/indexscanner/testdata/testindex/plugins/bar.yaml
+++ b/pkg/index/indexscanner/testdata/testindex/plugins/bar.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: plugin.krew.app/v1alpha1
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: bar

--- a/pkg/index/indexscanner/testdata/testindex/plugins/foo.yaml
+++ b/pkg/index/indexscanner/testdata/testindex/plugins/foo.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: plugin.krew.app/v1alpha1
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: foo

--- a/pkg/index/indexscanner/testdata/testindex/plugins/notyaml.txt
+++ b/pkg/index/indexscanner/testdata/testindex/plugins/notyaml.txt
@@ -1,4 +1,4 @@
-apiVersion: plugin.krew.app/v1alpha1
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: notyaml-plugin

--- a/pkg/index/indexscanner/testdata/testindex/plugins/wrongname.yaml
+++ b/pkg/index/indexscanner/testdata/testindex/plugins/wrongname.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: plugin.krew.app/v1alpha1
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: mismatchedname

--- a/pkg/index/validate.go
+++ b/pkg/index/validate.go
@@ -21,10 +21,17 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	currentAPIVersion = "krew.googlecontainertools.github.com/v1alpha2"
+)
+
 var (
 	safePluginRegexp = regexp.MustCompile(`^[\w-]+$`)
+
 	// windowsForbidden is taken from  https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file
-	windowsForbidden = []string{"CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"}
+	windowsForbidden = []string{"CON", "PRN", "AUX", "NUL", "COM1", "COM2",
+		"COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2",
+		"LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"}
 )
 
 // IsSafePluginName checks if the plugin Name is save to use.
@@ -40,8 +47,16 @@ func IsSafePluginName(name string) bool {
 	return true
 }
 
+func isSupportedAPIVersion(apiVersion string) bool {
+	return apiVersion == currentAPIVersion
+}
+
 // Validate TODO(lbb)
 func (p Plugin) Validate(name string) error {
+	if !isSupportedAPIVersion(p.APIVersion) {
+		return errors.Errorf("plugin manifest has apiVersion=%q, not supported in this version of krew (try updating plugin index or install a newer version of krew)", p.APIVersion)
+	}
+
 	if !IsSafePluginName(name) {
 		return errors.Errorf("the plugin name %q is not allowed, must match %q", name, safePluginRegexp.String())
 	}


### PR DESCRIPTION
We currently do not check apiVersion in plugin manifests and fail other
validation steps like "bin field is missing". This is confusing to users.

Adding an apiVersion check. Right now it's an exact match, but it should be ok.
When we can figure out how to parse k8s apiVersion format and compare them,
we can refactor this into isMinAPIversion().

This will require updates to many testdata files next time apiVersion is bumped.