### PR TITLE
Refactor hack/build-cross-releases.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,11 @@ deploy:
   provider: releases
   api_key:
     secure: f1xHUbLggyRUFikISqZM0VVsmSJFbZnLPMyiqsjZojwhmmAzRvAqZBuhAXGmFINNxf/UjTY+akVnpC/tlyW9h+KmSjpo+xx5shWX3vFPIAW909B57I0ZCpdhn+VOR17C7mAKW6apFAAVs5PrWdeoYSmRDHyMfIUhljwn+/Uw08b/OhaSYjOoxaeM+1FIYvILKx/3+b31pqH6HvQp9q8loLO7fYEMp7kTW/pQ+gSP7F6oEeZmYqwmGQ6+o4UlVldky4Aix6MQFfE1lFnTfyi6GtlMWLVALEfN7Z3CxdrwE5KFo/yguG1PmlfWx8TzqU6kr9u+EsaDez2FHi+5KabFZWd9sp/dyoN+MrqY5LTb+Rr12Uoyo9gvRu9lj75K7O73AwYKVf697YpMy8XXcM3C1QLcwjhePt3jKM7rv7grJab73EedEmUvCJxtQDXiVG2YoMRmr71z2LNKeP1G+yu0a4qHOpbo7l9x/HrQsVMsJ7p0l2/7bSrtZzS2i/atn8i2D8iKHIEu0ygHyZEQDO6wR9tzj+3qsCKS8O21vOf/pSD4VWXeeOdvenqkCaftRZoyFCbvpQn0z/IY1p2lJCJhSKAmnfOlIgDdylSTy1jOArShxa0HC/JC67f8TgUYvg6WYdejuK5UJtEWv6tADrk702JOMHIC1ILUIeEjy16pb/g=
+  file_glob: true
   file:
   - out/krew.zip
-  - out/krew-zip.sha256
-  - out/build/krew-linux_amd64
-  - out/build/krew-linux_arm
-  - out/build/krew-darwin_amd64
-  - out/build/krew-windows_amd64.exe
+  - out/krew.zip.sha256
+  - out/bin/krew-*
   skip_cleanup: true
   on:
     tags: true

--- a/hack/build-cross-releases.sh
+++ b/hack/build-cross-releases.sh
@@ -20,16 +20,23 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd "${SCRIPTDIR}/.."
 
+DEFAULT_OSARCH="darwin/amd64 windows/amd64 linux/amd64 linux/arm"
+KREW_ARCHIVE="krew.zip"
+
 # Builds
 rm -rf out/
-gox -osarch="darwin/amd64 windows/amd64 linux/amd64 linux/arm" \
+echo "Building releases: ${OSARCH:-$DEFAULT_OSARCH}"
+gox -osarch="${OSARCH:-$DEFAULT_OSARCH}" \
   -ldflags="-X github.com/GoogleContainerTools/krew/pkg/version.gitCommit=$(git rev-parse --short HEAD) \
     -X github.com/GoogleContainerTools/krew/pkg/version.gitTag=$(git describe --tags --dirty --always)" \
-  -output="out/build/krew-{{.OS}}_{{.Arch}}" \
+  -output="out/bin/krew-{{.OS}}_{{.Arch}}" \
   ./cmd/krew/...
 
-zip -X -q -r out/krew.zip out/build
+(
+  set -x;
+  zip -X -q -r --verbose out/krew.zip out/bin
+)
 
-KREW_HASH="$(shasum -a 256 out/krew.zip | awk '{print $1;}')"
-echo "Computed Hash: ${KREW_HASH}"
-echo "${KREW_HASH}" > out/krew-zip.sha256
+zip_checksum="$(shasum -a 256 "out/${KREW_ARCHIVE}" | awk '{print $1;}')"
+echo "${KREW_ARCHIVE} checksum: ${zip_checksum}"
+echo "${zip_checksum}" > "out/${KREW_ARCHIVE}".sha256


### PR DESCRIPTION
- allow customization of built os/arch (I use this to build darwin only when
  I am developing)
- change out/build to out/bin (I think we should use something more standard
  like ./dist instead out ./out in the first place but that can happen later)
- use globs while adding binaries to release (out/bin/krew-*)
- make sure .sha256 file has the same suffix as krew.zip (was krew-zip.sha256)