### PR TITLE
cmd: print stack traces for errors when glog.V>=1

### DIFF
--- a/cmd/krew/cmd/info.go
+++ b/cmd/krew/cmd/info.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/GoogleContainerTools/krew/pkg/index"
 	"github.com/GoogleContainerTools/krew/pkg/index/indexscanner"
-
 	"github.com/GoogleContainerTools/krew/pkg/installation"
-	"github.com/golang/glog"
+
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -33,16 +33,17 @@ var infoCmd = &cobra.Command{
 	Short: "Info shows plugin details",
 	Long: `Info shows plugin details.
 Use this command to find out about plugin requirements and caveats.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, arg := range args {
 			plugin, err := indexscanner.LoadPluginFileFromFS(paths.IndexPath(), arg)
 			if os.IsNotExist(err) {
-				glog.Fatalf("plugin %q not found", arg)
+				return errors.Errorf("plugin %q not found", arg)
 			} else if err != nil {
-				glog.Fatal(err)
+				return errors.Wrap(err, "failed to load plugin manifest")
 			}
 			printPluginInfo(os.Stdout, plugin)
 		}
+		return nil
 	},
 	PreRunE: checkIndex,
 	Args:    cobra.MinimumNArgs(1),

--- a/cmd/krew/cmd/root.go
+++ b/cmd/krew/cmd/root.go
@@ -47,7 +47,11 @@ You can invoke krew through kubectl with: "kubectl plugin [krew] option..."`,
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		glog.Fatal(err)
+		if glog.V(1) {
+			glog.Fatalf("%+v", err) // with stack trace
+		} else {
+			glog.Fatal(err) // just error message
+		}
 	}
 }
 
@@ -57,7 +61,6 @@ func init() {
 	flag.Set("logtostderr", "true")
 	// Required by glog
 	flag.Parse()
-
 	paths = environment.MustGetKrewPaths()
 	if err := ensureDirs(paths.BasePath(),
 		paths.DownloadPath(),
@@ -90,7 +93,7 @@ func setGlogFlags(hidden bool) {
 
 func checkIndex(_ *cobra.Command, _ []string) error {
 	if ok, err := gitutil.IsGitCloned(paths.IndexPath()); err != nil {
-		return err
+		return errors.Wrap(err, "failed to check local index git repository")
 	} else if !ok {
 		return errors.New(`krew local plugin index is not initialized (run "krew update")`)
 	}


### PR DESCRIPTION
- Added a decorator function that uses glog.V() to print stack traces from
  pkg/errors with %+v.
- Fixed a minor bug where specifying a non-existing plugin name to "upgrade"
  cmd was resulting in "" to be added to error string.

Examples:

	➜  kubectl krew upgrade foobar
	Updated index

	➜  kubectl krew upgrade foobar -v=1
	I1008 14:45:39.200042   15234 git.go:62] Going to run git pull --ff-only -v
	From https://github.com/GoogleContainerTools/krew-index
	 = [up to date]      master     -> origin/master
	Already up to date.
	Updated index
	I1008 14:45:39.669936   15234 scanner.go:74] Reading plugin "foobar"
	F1008 14:45:39.670188   15234 root.go:51] ERROR=open /Users/ahmetb/.krew/index/plugins/foobar.yaml: no such file or directory
	failed to load the index file for plugin foobar
	github.com/GoogleContainerTools/krew/cmd/krew/cmd.glob..func4
		/Users/ahmetb/workspace/gopath-krew/src/github.com/GoogleContainerTools/krew/cmd/krew/cmd/upgrade.go:59
	github.com/GoogleContainerTools/krew/cmd/krew/cmd.withStackTrace.func1
		/Users/ahmetb/workspace/gopath-krew/src/github.com/GoogleContainerTools/krew/cmd/krew/cmd/root.go:113
	github.com/GoogleContainerTools/krew/vendor/github.com/spf13/cobra.(*Command).execute
		/Users/ahmetb/workspace/gopath-krew/src/github.com/GoogleContainerTools/krew/vendor/github.com/spf13/cobra/command.go:762
	github.com/GoogleContainerTools/krew/vendor/github.com/spf13/cobra.(*Command).ExecuteC
		/Users/ahmetb/workspace/gopath-krew/src/github.com/GoogleContainerTools/krew/vendor/github.com/spf13/cobra/command.go:852
	github.com/GoogleContainerTools/krew/vendor/github.com/spf13/cobra.(*Command).Execute
		/Users/ahmetb/workspace/gopath-krew/src/github.com/GoogleContainerTools/krew/vendor/github.com/spf13/cobra/command.go:800
	github.com/GoogleContainerTools/krew/cmd/krew/cmd.Execute
		/Users/ahmetb/workspace/gopath-krew/src/github.com/GoogleContainerTools/krew/cmd/krew/cmd/root.go:50
	main.main
		/Users/ahmetb/workspace/gopath-krew/src/github.com/GoogleContainerTools/krew/cmd/krew/main.go:23
	runtime.main
		/Users/ahmetb/.homebrew/Cellar/go/1.11.1/libexec/src/runtime/proc.go:201
	runtime.goexit
		/Users/ahmetb/.homebrew/Cellar/go/1.11.1/libexec/src/runtime/asm_amd64.s:1333