### PR TITLE
pkg/install: isWindows respects KREW_OS

### DIFF
--- a/pkg/installation/install.go
+++ b/pkg/installation/install.go
@@ -167,7 +167,13 @@ func removeLink(path string) error {
 	return nil
 }
 
-func isWindows() bool { return runtime.GOOS == "windows" }
+func isWindows() bool {
+	goos := runtime.GOOS
+	if env := os.Getenv("KREW_OS"); env != "" {
+		goos = env
+	}
+	return goos == "windows"
+}
 
 // pluginNameToBin creates the name of the symlink file for the plugin name.
 // It converts dashes to underscores.

--- a/pkg/installation/install_test.go
+++ b/pkg/installation/install_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/GoogleContainerTools/krew/pkg/index"
@@ -195,5 +196,27 @@ func Test_removeLink_regularFileExists(t *testing.T) {
 
 	if err := removeLink(path); err == nil {
 		t.Fatalf("removeLink(%s) with regular file was expected to fail; got: err=nil", path)
+	}
+}
+
+func Test_isWindows(t *testing.T) {
+	expected := runtime.GOOS == "windows"
+	got := isWindows()
+	if expected != got {
+		t.Fatalf("isWindows()=%v; expected=%v (on %s)", got, expected, runtime.GOOS)
+	}
+}
+
+func Test_isWindows_envOverride(t *testing.T) {
+	defer os.Unsetenv("KREW_OS")
+
+	os.Setenv("KREW_OS", "windows")
+	if !isWindows() {
+		t.Fatalf("isWindows()=false when KREW_OS=windows")
+	}
+
+	os.Setenv("KREW_OS", "not-windows")
+	if isWindows() {
+		t.Fatalf("isWindows()=true when KREW_OS != windows")
 	}
 }


### PR DESCRIPTION
This will allow .exe symlinks to be constructed successfully when
KREW_OS=windows is set, but krew is running on a different GOOS.