### PR TITLE
cmd: refactor table printing code

### DIFF
--- a/cmd/krew/cmd/search.go
+++ b/cmd/krew/cmd/search.go
@@ -15,10 +15,8 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/GoogleContainerTools/krew/pkg/index/indexscanner"
 	"github.com/pkg/errors"
@@ -67,9 +65,8 @@ Search accepts a list of words as options.`,
 			return nil
 		}
 
-		rowPattern := "%s\t%s\t%s\n"
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
-		fmt.Fprintf(w, rowPattern, "NAME", "DESCRIPTION", "STATUS")
+		var rows [][]string
+		cols := []string{"NAME", "DESCRIPTION", "STATUS"}
 		for _, name := range matchNames {
 			plugin := pluginMap[name]
 			var status string
@@ -82,10 +79,10 @@ Search accepts a list of words as options.`,
 			} else {
 				status = "unavailable"
 			}
-			fmt.Fprintf(w, rowPattern, name, limitString(plugin.Spec.ShortDescription, 50), status)
+			rows = append(rows, []string{name, limitString(plugin.Spec.ShortDescription, 50), status})
 		}
-		w.Flush()
-		return nil
+		rows = sortByFirstColumn(rows)
+		return printTable(os.Stdout, cols, rows)
 	},
 	PreRunE: checkIndex,
 }

--- a/cmd/krew/cmd/version.go
+++ b/cmd/krew/cmd/version.go
@@ -34,20 +34,20 @@ IndexPath is the path to the index repo see git(1).
 IndexURI is the URI where the index is updated from.
 InstallPath is the base path for all plugin installations.
 DownloadPath is the path used to store download binaries.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		conf := map[string]string{
-			"IsPlugin":        fmt.Sprintf("%v", krewExecutedVersion != ""),
-			"ExecutedVersion": krewExecutedVersion,
-			"GitTag":          version.GitTag(),
-			"GitCommit":       version.GitCommit(),
-			"BasePath":        paths.BasePath(),
-			"IndexPath":       paths.IndexPath(),
-			"IndexURI":        IndexURI,
-			"InstallPath":     paths.InstallPath(),
-			"DownloadPath":    paths.DownloadPath(),
-			"BinPath":         paths.BinPath(),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		conf := [][]string{
+			{"IsPlugin", fmt.Sprintf("%v", krewExecutedVersion != "")},
+			{"ExecutedVersion", krewExecutedVersion},
+			{"GitTag", version.GitTag()},
+			{"GitCommit", version.GitCommit()},
+			{"IndexURI", IndexURI},
+			{"BasePath", paths.BasePath()},
+			{"IndexPath", paths.IndexPath()},
+			{"InstallPath", paths.InstallPath()},
+			{"DownloadPath", paths.DownloadPath()},
+			{"BinPath", paths.BinPath()},
 		}
-		printAlignedColumns(os.Stdout, "OPTION", "VALUE", conf)
+		return printTable(os.Stdout, []string{"OPTION", "VALUE"}, conf)
 	},
 }
 


### PR DESCRIPTION
- convert 2-column printing code to general-purpose table printer (printTable)
- deduplicate tabwriter calls from list/version/search into printTable
- do not discard errors from printTable in cmds (return from RunE)
- cmd/version: do not sort fields (looks more organized)