### PR TITLE
hack: add google cloud build steps

### DIFF
--- a/hack/Dockerfile.build
+++ b/hack/Dockerfile.build
@@ -1,0 +1,24 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Used by cloudbuild*.yaml to build in Google Cloud Build.
+FROM golang:1-alpine
+RUN apk add -q --no-cache bash git zip
+RUN go get github.com/mitchellh/gox
+
+ENV PROJECT_ROOT /go/src/github.com/GoogleContainerTools/krew
+RUN mkdir -p $(dirname $PROJECT_ROOT) && \
+        ln -s /workspace $PROJECT_ROOT
+WORKDIR $PROJECT_ROOT
+ENTRYPOINT $PROJECT_ROOT/hack/build-cross-releases.sh

--- a/hack/build-cross-releases.sh
+++ b/hack/build-cross-releases.sh
@@ -28,10 +28,14 @@ rm -rf out/
 
 # Builds
 echo "Building releases: ${OSARCH:-$DEFAULT_OSARCH}"
+git_rev="${SHORT_SHA:-$(git rev-parse --short HEAD)}"
+git_tag="${TAG_NAME:-$(git describe --tags --dirty --always)}"
+echo "Stamping with git tag=${git_tag} rev=${git_rev}"
+
 env CGO_ENABLED=0 gox -osarch="${OSARCH:-$DEFAULT_OSARCH}" \
   -tags netgo \
-  -ldflags="-w -X ${version_pkg}.gitCommit=$(git rev-parse --short HEAD) \
-    -X ${version_pkg}.gitTag=$(git describe --tags --dirty --always)" \
+  -ldflags="-w -X ${version_pkg}.gitCommit=${git_rev} \
+    -X ${version_pkg}.gitTag=${git_tag}" \
   -output="out/bin/krew-{{.OS}}_{{.Arch}}" \
   ./cmd/krew/...
 

--- a/hack/cloudbuild-release.yaml
+++ b/hack/cloudbuild-release.yaml
@@ -1,0 +1,26 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Used to push tagged releses to Google Cloud Storage with the tag name
+# as well as "latest"
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'builder', '-f', 'hack/Dockerfile.build', '.']
+  - name: 'builder'
+  - name: 'gcr.io/cloud-builders/gsutil'
+    args: ['-m', 'cp', '-r', 'out/*', 'gs://krew/$TAG_NAME/']
+  - name: 'gcr.io/cloud-builders/gsutil'
+    args: ['-m', 'cp', '-r', 'out/*', 'gs://krew/latest/']
+options:
+  machineType: 'N1_HIGHCPU_8'

--- a/hack/cloudbuild.yaml
+++ b/hack/cloudbuild.yaml
@@ -1,0 +1,23 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Used to push builds to Google Cloud Storage.
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'builder', '-f', 'hack/Dockerfile.build', '.']
+  - name: 'builder'
+  - name: 'gcr.io/cloud-builders/gsutil'
+    args: ['-m', 'cp', '-r', 'out/*', 'gs://krew/builds/$SHORT_SHA/']
+options:
+  machineType: 'N1_HIGHCPU_8'


### PR DESCRIPTION
- Dockerfile: build environment
- cloudbuild*.yaml: steps for building and pushing artifacts

Fixes #84.