### PR TITLE
Refactor release scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,22 +14,9 @@ script:
 - hack/gofmt.sh
 - hack/gometalinter.sh
 - go test -v -coverprofile=coverage.txt -covermode=atomic ./...
-- hack/build-cross-releases.sh
+- hack/make-all.sh
 after_success:
 - bash <(curl -s https://codecov.io/bash)
-deploy:
-  provider: releases
-  api_key:
-    secure: f1xHUbLggyRUFikISqZM0VVsmSJFbZnLPMyiqsjZojwhmmAzRvAqZBuhAXGmFINNxf/UjTY+akVnpC/tlyW9h+KmSjpo+xx5shWX3vFPIAW909B57I0ZCpdhn+VOR17C7mAKW6apFAAVs5PrWdeoYSmRDHyMfIUhljwn+/Uw08b/OhaSYjOoxaeM+1FIYvILKx/3+b31pqH6HvQp9q8loLO7fYEMp7kTW/pQ+gSP7F6oEeZmYqwmGQ6+o4UlVldky4Aix6MQFfE1lFnTfyi6GtlMWLVALEfN7Z3CxdrwE5KFo/yguG1PmlfWx8TzqU6kr9u+EsaDez2FHi+5KabFZWd9sp/dyoN+MrqY5LTb+Rr12Uoyo9gvRu9lj75K7O73AwYKVf697YpMy8XXcM3C1QLcwjhePt3jKM7rv7grJab73EedEmUvCJxtQDXiVG2YoMRmr71z2LNKeP1G+yu0a4qHOpbo7l9x/HrQsVMsJ7p0l2/7bSrtZzS2i/atn8i2D8iKHIEu0ygHyZEQDO6wR9tzj+3qsCKS8O21vOf/pSD4VWXeeOdvenqkCaftRZoyFCbvpQn0z/IY1p2lJCJhSKAmnfOlIgDdylSTy1jOArShxa0HC/JC67f8TgUYvg6WYdejuK5UJtEWv6tADrk702JOMHIC1ILUIeEjy16pb/g=
-  file_glob: true
-  file:
-  - out/krew.zip
-  - out/krew.zip.sha256
-  - out/krew.yaml
-  - out/bin/krew-*
-  skip_cleanup: true
-  on:
-    tags: true
 env:
   global:
   - secure: Ly5oLE9sC7NDvwyZEzOi8gPeHdu3NTP2OuDa8BOUngAanXhaEInzBJ+Pod+TIKFzpope4/z8idMN3rZfPV5LcXzhufk82LSpYlGhZgFDYajvv3eNN20arZQf4kjohd5U2aY1XrYgrgBbodv7dCLnitxotO65tTzQN5xh6evwW6Ji2Em7t42kvz9VHj2nptWKsciQEr6KNb2xDJ7PSvFKdPKq0q3Vuy7PFToZvNbsk+FBLSjYpAHG1KrlyX/WiM1mLu7jCJ4yuPx4n9+CM5Zzycbc/6mrs8ZiR+myyaCMzh6pEltdR0vzSlFIl2TJvUwzTUyTXcZsQ/ENa1ZdOkQwI4jpV3IDTQ6AlMRtBSbL5/uSOvHYs1HBYTbJJeZLiMjru9SM6D9AUW9HRr0JQGeQFsPE/4mzl39Xgl+3GE4+6sfNiaurpvgNArQNBAs2nZ0V3myiDoSG/sAL/2YzXHiG0HVhVk65P33d9SevJjBJRTobhRf4Lt0lT2IO6XF/4kQIvMnaCPQRS1X5tMIHFeTzn1dwrFiZqd1Sbwq5cd8H25nt1XnXsCTgRegJPNUxqRHnDpR5M3HRiW+TmjJIte7Y6exCihonM3afj3rsu3Q/ePwj7ckzgq8CP2yJ//Sxu4FH65LGQ/2bHJUneKL33Uq1W68c+qtKWMGLB4LNRGJVZkc=

--- a/hack/make-all.sh
+++ b/hack/make-all.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,13 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Used by cloudbuild*.yaml to build in Google Cloud Build.
-FROM golang:1-alpine
-RUN apk add -q --no-cache bash git zip
-RUN go get github.com/mitchellh/gox
+set -e -o pipefail
 
-ENV PROJECT_ROOT /go/src/github.com/GoogleContainerTools/krew
-RUN mkdir -p $(dirname $PROJECT_ROOT) && \
-        ln -s /workspace $PROJECT_ROOT
-WORKDIR $PROJECT_ROOT
-ENTRYPOINT $PROJECT_ROOT/hack/make-all.sh
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+"${SCRIPTDIR}/make-binaries.sh"
+"${SCRIPTDIR}/make-release-artifacts.sh"

--- a/hack/make-release-artifacts.sh
+++ b/hack/make-release-artifacts.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e -o pipefail
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "${SCRIPTDIR}/.."
+
+bin_dir="out/bin"
+if [[ ! -d "${bin_dir}" ]]; then
+    echo >&2 "Binaries are not built (${bin_dir}), run build-binaries.sh"
+    exit 1
+fi
+
+krew_archive="krew.zip"
+echo >&2 "Creating ${krew_archive} archive."
+zip -X -q -r --verbose out/krew.zip "${bin_dir}"
+
+checksum_cmd="shasum -a 256"
+if hash sha256sum 2>/dev/null; then
+  checksum_cmd="sha256sum"
+fi
+zip_checksum="$(eval "${checksum_cmd[@]}" "out/${krew_archive}" | awk '{print $1;}')"
+sumfile="out/${krew_archive}.sha256"
+echo >&2 "${krew_archive} checksum: ${zip_checksum}"
+echo >&2 "${zip_checksum}" > "${sumfile}"
+echo >&2 "Written ${sumfile}."
+
+# Copy and process krew manifest
+cp ./hack/krew.yaml ./out/krew.yaml
+tag="$(git describe --tags HEAD)"
+sed -i "s/KREW_ZIP_CHECKSUM/${zip_checksum}/g" ./out/krew.yaml
+sed -i "s/KREW_TAG/${tag}/g" ./out/krew.yaml
+echo >&2 "Written krew.yaml."


### PR DESCRIPTION
- disable travis github deploys on tags (fixes #89)
- split binary building (can also be used during development) and release
  artifact building (krew.{yaml,zip{,sha256}}). we should probably convert
  this to a makefile sometime.