### PR TITLE
cmd: deduplicate isTerminal detection

### DIFF
--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -24,7 +24,6 @@ import (
 	"github.com/GoogleContainerTools/krew/pkg/installation"
 
 	"github.com/golang/glog"
-	"github.com/mattn/go-isatty"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -43,12 +42,12 @@ All plugins will be downloaded and made available to: "kubectl plugin <name>"`,
 			var pluginNames = make([]string, len(args))
 			copy(pluginNames, args)
 
-			if (len(pluginNames) != 0 || *manifest != "") && !(isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd())) {
-				fmt.Fprintln(os.Stderr, "Detected Stdin, but discarding it because of --manifest or args")
+			if !isTerminal(os.Stdin) && (len(pluginNames) != 0 || *manifest != "") {
+				fmt.Fprintln(os.Stderr, "WARNING: Detected stdin, but discarding it because of --manifest or args")
 			}
 
-			if len(pluginNames) == 0 && *manifest == "" && !(isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd())) {
-				fmt.Fprintln(os.Stderr, "Read from standard input")
+			if !isTerminal(os.Stdin) && (len(pluginNames) == 0 && *manifest == "") {
+				fmt.Fprintln(os.Stderr, "Reading plugin names via stdin")
 				scanner := bufio.NewScanner(os.Stdin)
 				scanner.Split(bufio.ScanLines)
 				for scanner.Scan() {

--- a/cmd/krew/cmd/list.go
+++ b/cmd/krew/cmd/list.go
@@ -23,7 +23,6 @@ import (
 	"text/tabwriter"
 
 	"github.com/GoogleContainerTools/krew/pkg/installation"
-	"github.com/mattn/go-isatty"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -42,7 +41,7 @@ Plugins will be shown as "PLUGIN,VERSION"`,
 			}
 
 			// return sorted list of plugin names when piped to other commands or file
-			if !(isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())) {
+			if !isTerminal(os.Stdout) {
 				var names []string
 				for name := range plugins {
 					names = append(names, name)

--- a/cmd/krew/cmd/root.go
+++ b/cmd/krew/cmd/root.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/GoogleContainerTools/krew/pkg/environment"
 	"github.com/GoogleContainerTools/krew/pkg/gitutil"
+	isatty "github.com/mattn/go-isatty"
 	"github.com/pkg/errors"
 
 	"github.com/golang/glog"
@@ -108,6 +109,10 @@ func ensureDirs(paths ...string) error {
 		}
 	}
 	return nil
+}
+
+func isTerminal(f *os.File) bool {
+	return isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
Fixes #81. There's a bunch of odd rules in the parsing of stdin vs args vs
--manifest. We might need to simplify it and be more strict.