### PR TITLE
cmd: refactor install output

### DIFF
--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -98,13 +98,13 @@ All plugins will be downloaded and made available to: "kubectl plugin <name>"`,
 
 			// Print plugin namesFromFile
 			for _, plugin := range install {
-				fmt.Fprintf(os.Stderr, "Will install plugin: %s\n", plugin.Name)
+				glog.V(2).Infof("Will install plugin: %s\n", plugin.Name)
 			}
 
 			var failed []string
 			// Do install
 			for _, plugin := range install {
-				glog.V(2).Infof("Installing plugin: %s\n", plugin.Name)
+				fmt.Fprintf(os.Stderr, "Installing plugin: %s\n", plugin.Name)
 				err := installation.Install(paths, plugin, *forceHEAD, *forceDownloadFile)
 				if err == installation.ErrIsAlreadyInstalled {
 					glog.Warningf("Skipping plugin %s, it is already installed", plugin.Name)
@@ -115,10 +115,10 @@ All plugins will be downloaded and made available to: "kubectl plugin <name>"`,
 					failed = append(failed, plugin.Name)
 					continue
 				}
-				fmt.Fprintf(os.Stderr, "Installed plugin: %s\n", plugin.Name)
 				if plugin.Spec.Caveats != "" {
 					fmt.Fprintf(os.Stderr, "CAVEATS: %s\n", plugin.Spec.Caveats)
 				}
+				fmt.Fprintf(os.Stderr, "Installed plugin: %s\n", plugin.Name)
 			}
 			if len(failed) > 0 {
 				return errors.Errorf("failed to install some plugins: %+v", failed)

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -52,6 +52,7 @@ Plugins can be installed with `kubectl krew install` command:
 $ kubectl krew install ca-cert
 
 Will install plugin: ca-cert
+Installing plugin: ca-cert
 Installed plugin: ca-cert
 CAVEATS:
  This plugin needs the following programs:


### PR DESCRIPTION
- print caveats before "installed %s"
- downgrade "will install plugin" to glog.v(2)
- add "installing plugin" before starting install so each plugin looks like
  "installing %s" and "installed %s" (looks better while downloading binaries).