### PR TITLE
cmd: pretty print caveats output

### DIFF
--- a/cmd/krew/cmd/info.go
+++ b/cmd/krew/cmd/info.go
@@ -18,6 +18,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
+	"strings"
+	"unicode"
 
 	"github.com/GoogleContainerTools/krew/pkg/index"
 	"github.com/GoogleContainerTools/krew/pkg/index/indexscanner"
@@ -67,8 +70,26 @@ func printPluginInfo(out io.Writer, plugin index.Plugin) {
 		fmt.Fprintf(out, "VERSION: %s\n", plugin.Spec.Version)
 	}
 	if plugin.Spec.Caveats != "" {
-		fmt.Fprintf(out, "CAVEATS: \n%s\n", plugin.Spec.Caveats)
+		fmt.Fprintf(out, prepCaveats(plugin.Spec.Caveats))
 	}
+}
+
+// prepCaveats converts caveats string to an indented format ready for printing.
+// Example:
+//
+//     CAVEATS:
+//     \
+//      | This plugin is great, use it with great care.
+//      | Also, plugin will require the following programs to run:
+//      |  * jq
+//      |  * base64
+//     /
+func prepCaveats(s string) string {
+	out := "CAVEATS:\n\\\n"
+	s = strings.TrimRightFunc(s, unicode.IsSpace)
+	out += regexp.MustCompile("(?m)^").ReplaceAllString(s, " |  ")
+	out += "\n/\n"
+	return out
 }
 
 func init() {

--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -117,7 +117,7 @@ All plugins will be downloaded and made available to: "kubectl plugin <name>"`,
 				}
 				fmt.Fprintf(os.Stderr, "Installed plugin: %s\n", plugin.Name)
 				if plugin.Spec.Caveats != "" {
-					fmt.Fprintf(os.Stderr, "CAVEATS: %s\n", plugin.Spec.Caveats)
+					fmt.Fprintf(os.Stderr, prepCaveats(plugin.Spec.Caveats))
 				}
 			}
 			if len(failed) > 0 {


### PR DESCRIPTION
Example:

	Installing plugin: ca-cert
	CAVEATS:
	\
	 |  This plugin needs the following programs:
	 |  * base64
	/
	Installed plugin: ca-cert
	Installing plugin: debug-shell
	Installed plugin: debug-shell
	Installing plugin: exec-all
	CAVEATS:
	\
	 |  Usage:
	 |    kubectl plugin exec-all <RESOURCE_TYPE> <RESOURCE_NAME> -- <COMMAND>
	 |  This plugin needs the following programs:
	 |  * jq
	 |  * xargs
	 |  * bash
	/
	Installed plugin: exec-all
	Installing plugin: gke-credentials
	CAVEATS:
	\
	 |  This plugin needs the following programs:
	 |  * gcloud
	/
	Installed plugin: gke-credentials
	Installing plugin: mtail
	CAVEATS:
	\
	 |  This plugin needs the following programs:
	 |  * jq
	/
	Installed plugin: mtail
	Installing plugin: node-admin
	Installed plugin: node-admin