### PR TITLE
docs: revamp the DEVELOPER_GUIDE

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -1,38 +1,64 @@
 # Developer Guide
 
 This guide is intended for plugin developers. If you are not developing kubectl
-plugins, read the [User Guide](./USER_GUIDE.md).
+plugins, read the [User Guide](./USER_GUIDE.md) to learn how to use krew.
 
 This guide explains how to package, test, run plugins locally and make them
 available on the krew index.
 
-## Creating a Plugin
+<!-- TOC -->
 
-Please read the
-[Official plugin docs](https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/)
-to learn about plugins.
+- [Developer Guide](#developer-guide)
+- [Developing a Plugin](#developing-a-plugin)
+    - [Packaging plugins for krew](#packaging-plugins-for-krew)
+    - [Writing a plugin manifest](#writing-a-plugin-manifest)
+        - [Specifying platform-specific instructions](#specifying-platform-specific-instructions)
+        - [Specifying files to install](#specifying-files-to-install)
+        - [Specifying plugin executable](#specifying-plugin-executable)
+        - [Specifying a plugin download URL](#specifying-a-plugin-download-url)
+- [Installing Plugins Locally](#installing-plugins-locally)
+- [Publishing Plugins](#publishing-plugins)
+    - [Submitting a plugin to krew](#submitting-a-plugin-to-krew)
+    - [Updating existing plugins](#updating-existing-plugins)
 
-This document shows how to create a plugin named `foo`.
-The plugin shows the environment variables on unix and windows systems.
+<!-- /TOC -->
 
-First, create a public GitHub repository for the plugin.
-In this repository there should be two plugin files:
+# Developing a Plugin
 
-`unix/kubectl-foo`
+Before creating a plugin, read the [Kubernetes Plugins documentation][plugins].
 
-```yaml
-#!/bin/bash
+In this this document you will create a plugin named `foo` which prints the
+environment variables to the screen and exits.
+
+Read the [Naming Guide](./NAMING_GUIDE.md) for choosing a name for your plugin.
+
+Create an executable file named `kubectl-foo.sh` with the following contents:
+
+```bash
+#!/usr/bin/env bash
 env
 ```
 
-For Windows build an `.exe` file and save it to `windows/kubectl-foo`.
+Then make this script executable:
 
-See [Plugin Naming Style Guide](NAMING_GUIDE.md) for choosing the right name
-for your plugin.
+    chmod +x ./kubectl-foo.sh
 
-Commit and push the new files to your public repository.
+Since this plugin requires `bash`, it will only work on Unix platforms. If you
+need to support windows, develop a `kubectl-foo.exe` executable.
 
-### Making Plugins Publicly Accessible
+Now, if you place this plugin to anywhere in your `$PATH` directories, you
+should be able to call it like:
+
+    kubectl foo
+
+
+## Packaging plugins for krew
+
+To make a plugin installable via krew, you need to:
+
+1. Provide a **publicly downloadable** archive file (`.zip` or `.tar.gz`)
+2. Write a plugin manifest file (`<plugin>.yaml`) and make it available on
+   [krew index][index]
 
 Plugin packages need to be available to download from the public Internet.
 A service like
@@ -41,256 +67,249 @@ is recommended.
 It is also possible to get the latest release for a GitHub repository from the
 URL: `https://github.com/<user>/<project>/archive/master.zip`.
 
-### Writing a Plugin Index File
+## Writing a plugin manifest
 
-Each krew plugin has a "plugin index manifest" file that lives in the index
-repository. This file describes which files to install from the provided
-archive. The index plugin index manifest file allows krew to manage your plugin
-installation.
+Each krew plugin has a "plugin manifest" file that lives in the [krew index
+repository][krew].
 
-### Example Plugin Index File
+This file describes which files krew must copy out of your plugin archive and
+how to run your plugin. It is also used to determine if an upgrade to your
+plugin is available and how to install it.
+
+For the plugin named `foo` that runs only on Linux and macOS, the plugin
+manifest looks like this.
 
 ```yaml
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
-  name: foo
+  name: foo               # plugin name must match your manifest file name
 spec:
+  version: "v0.0.1"       # optional, only for documentation purposes
   platforms:
-  - selector: # A regular Kubernetes label selector
+  # specify installation script for linux and darwin (macOS)
+  - selector:             # a regular Kubernetes selector
       matchExpressions:
-      - {key: os, operator: In, values: [darwin, linux]} 
-    head: https://github.com/barbaz/foo/archive/master.zip
-    bin: "./kubectl-foo"
-    # This is used during installation. It uses file Globs to copy required files.
-    files:
-    - from: "/unix/*"
+      - {key: os, operator: In, values: [darwin, linux]}
+    url: https://github.com/example/foo/releases/v1.0.zip
+    sha256: "208fde0b9f42ef71f79864b1ce594a70832c47dc5426e10ca73bf02e54d499d0"
+    files:                # copy the used files out of the zip file
+    - from: "unix/*"
       to: "."
-  - selector:
-      matchLabels:
-        os: windows
-    head: https://github.com/barbaz/foo/archive/master.zip
-    bin: "./kubectl-foo.exe"
-    files:
-    - from: "/windows/*"
-      to: "."
-  # Version does not follow any conventions and is not functional.
-  version: "v0.0.1"
-  shortDescription: Short description of foo
-  description: |
-      This plugin shows all environment
-      variables that get injected when
-      launching a program as a plugin.
-      All environment variables are
-      prefixed with KUBECTL_*
+    bin: "./kubectl-foo"  # path to the plugin executable after extracting files
+  shortDescription: Prints the environment variables.
+  # (optional) use caveats field to show post-installation recommendations
   caveats: |
     This plugin needs the following programs:
-    * env (unix)
-    * SET (windows)
-```
-
-Choose a name for your plugin.
-A plugin name must be unique within the krew index.
-The name can contain alphanumeric characters and dashes.
-
-The following YAML file, named `foo.yaml`,
-shows the manifest for a plugin named `foo`:
-
-```yaml
-apiVersion: krew.googlecontainertools.github.com/v1alpha2
-kind: Plugin
-metadata:
-  name: foo
-...
-```
-
----
-
-To give some more information about a plugin provide a
-`shortDescription` and `description`:
-
-```yaml
-...
-  shortDescription: Short description of foo
+    * env(1)
   description: |
-      This plugin shows all environment
-      variables that get injected when
-      launching a programm as a plugin.
-      All environment variables are
-      prefixed with KUBECTL_*
-...
+    This plugin shows all environment variables that get injected when
+    launching a program as a plugin. You can use this field for longer
+    description and example usages.
 ```
 
----
+### Specifying platform-specific instructions
 
-The version field is not used by krew and is not required; however,
-you can use this field to provide users a way to show the version number of
-your plugin.
+krew makes it possible to install the same plugin on different operating systems
+(like `windows`, `darwin` (macOS), and `linux`) and different architectures
+(like `amd64`, `386`, `arm`).
+
+To support multiple platforms, you may need to define multiple `platforms` in
+the plugin manifest. The `selector` field matches to operating systems and
+architectures using the keys `os` and `arch` respectively.
+
+**Example:** Match to Linux:
 
 ```yaml
-...
-  version: "v0.0.1"
-...
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
 ```
 
----
-
-To allow a plugin to work on different platforms, you can specify different
-target platforms those are stored in the `platforms` array:
+**Example:** Match to a Linux or macOS platform, any architecure:
 
 ```yaml
 ...
   platforms:
   - selector: # A regular Kubernetes label selector
       matchExpressions:
-      - {key: os, operator: In, values: [darwin, linux]} 
-    ...
+      - {key: os, operator: In, values: [darwin, linux]}
+```
+
+**Example:** Match to Windows 64-bit:
+
+```yaml
+  platforms:
   - selector:
       matchLabels:
         os: windows
-    ...
-...
+        arch: amd64
 ```
 
-This plugin works on *Linux*, *macOS* and *Windows*.
-Krew uses Kubernetes
-[Label Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
-to match for the platform specific keys `os` and `arch`.
-The values come from golang's
-[GOOS and GOARCH](https://golang.org/pkg/runtime/#pkg-constants).
-The label selectors are evaluated on the user's machine during the installation.
+The possible values for `os` and `arch`  come from the Go runtime. Run
+`go tool dist list` to see all possible platforms and architectures.
 
----
+### Specifying files to install
 
-Each operating system may require a different set of files from the
-archive to be installed. You can use the `files` field to specify them.
-The `file:` list specifies operations (like `mv(1) <from> <to>`) to copy
+Each operating system may require a different set of files from the archive to
+be installed. You can use the `files` field in the plugin manifest to specify
+which files should be copied into the plugin directory after extracting the
+plugin archive.
+
+The `file:` list specifies the copy operations (like `mv(1) <from> <to>`) to
 the files `from` the archive `to` the installation destination.
 
-After executing the move operations,
-the resulting directory must contain a plugin descriptor file (`plugin.yaml`).
+**Example:** Copy all files in the `bin/` directory of the extracted archive to
+the root of your plugin:
 
 ```yaml
-...
     files:
-    - from: "/unix/*"
-      to: "."
-...
+    - from: bin/*.exe
+      to: .
 ```
 
-This file operation moves all files from the `/unix/*` directory to the
-root of the installation directory.
-
-Given the file operation above, assume the plugin archive looks like this:
+Given the file operation above, if the extracted plugin archive looked like
+this:
 
 ```text
 .
-├── unix
-│   └── kubectl-foo
-└── windows
-    └── kubectl-foo.exe
+├── README.txt
+├── README.txt
+└── bin
+│   └── kubectl-foo-linux
+    └── kubectl-foo-windows.exe
 ```
 
-The resulting installation directory will look like:
-
-```text
+The resulting installation directory would up just with:
+```
 .
-└── plugin.yaml
+└── krew-foo-windows.exe
 ```
 
----
+### Specifying plugin executable
 
-Krew creates a symbolic link to the plugin executable specified in the
-`bin` field in `$HOME/.krew/bin/` (which needs to be added to your
-`$PATH`).
+Each `platform` field requires a path to the plugin executable in the plugin's
+installation directory.
+
+krew creates a symbolic link to the plugin executable specified in the `bin`
+field in `$HOME/.krew/bin/` (which all krew users need to add to their `$PATH`).
+
+For example, if your plugin executable is named `start-foo.sh`, specify:
 
 ```yaml
-...
-    bin: "./kubectl-foo"
-...
+platforms:
+  - bin: "./start-foo.sh"
+    ...
 ```
 
----
+krew will create a [symbolic link](https://en.wikipedia.org/wiki/Symbolic_link)
+named `kubectl-foo` (and `kubectl-foo.exe` on Windows) to your plugin executable
+after installation is complete. The name of the symbolic link comes from the
+plugin name.
 
-There are two ways to specify a plugin archive location:
+> **Note on underscore conversion:** If your plugin name contains dashes, krew
+> will automatically convert them to underscores for kubectl to be able to find
+> your plugin.
+>
+> For example, if your  is named `view-logs` and your plugin binary is named
+> `run.sh`, krew will create a symbolic named `kubectl-view_logs` automatically.
 
-1. Download from a URL pointing and verify its checksum with sha256.
-   This uses `url` and `sha256` fields.
-2. Download from a URL without verifying its checksum.
-   This uses the `head` field. You can use this for development.
+### Specifying a plugin download URL
 
-Versioned files have two fields that need to be specified:
+krew plugins must be packaged as `.zip` or `.tar.gz` archives and should be made
+available to download publicly.
 
-1. The `sha256` hash of the archive that is will be downloaded.
-2. The `uri` where the archive can be found. 
+There are two ways to specify a plugin archive location in the plugin manifest:
 
-When you specify a HEAD, it is enough to enter the `head` url.
-it is intended that the HEAD points archive always to the latest release.
-The checksum of the archive file specified on `head` won't be verified. 
+1. Download from a URL pointing and verify its checksum with sha256:
+   This uses `url` and `sha256` fields. **(recommended)**
+2. Download from a URL without verifying its checksum:
+   This uses the `head` field. This is intended for development purposes where
+   the contents of the URL may change frequently.
+
+Downloading from a versioned URL requires fields:
+
+- `uri`: URL to the archive file (`.zip` or `.tar.gz`)
+- `sha256`: sha256 sum of the archive file
+
+
+Specifying `head` field makes it possible to install a file without verifying
+its checksum. If you are downloading from `master` branch of a GitHub
+repository, this can be useful. Users can install a plugin using the `head`
+with:
+
+    kubectl krew install --HEAD <PLUGIN>
+
+It is possible to specify only the `head`, as well as alongside `uri` and `sha256`. In
+this case, the `uri` and `sha256` fields will be used by default:
 
 ```yaml
-...
-    head: https://github.com/barbaz/foo/archive/master.zip
+  platforms:
+  - head: https://github.com/barbaz/foo/archive/master.zip
     uri: https://github.com/barbaz/foo/archive/v1.2.3.zip
     sha256: "29C9C411AF879AB85049344B81B8E8A9FBC1D657D493694E2783A2D0DB240775"
-...
+    ...
 ```
 
-### Running the Plugin Locally
+# Installing Plugins Locally
 
-To test the plugin locally before uploading it to the [Main Index], you can
-install it locally by providing the manifest file:
+After you have:
+- written your `<PLUGIN>.yaml`
+- archived your plugin into a `.zip` or `.tar.gz` file
+
+you can now test whether your plugin installs correctly on krew by running:
 
 ```bash
-kubectl krew install -v=4 --manifest=./foo.yaml
+kubectl krew install --manifest=foo.yaml --archive=foo.yaml
 ```
 
-If you did not make the plugin archive available on the `uri` yet, you can use
-a local file in the `--archive` flag while specifying a custom manifest. This
-will ignore the URL specified in the `uri:` and use the local file (but will
-still use `sha256` field to do integrity check):
+- `--manifest` flag specifies a custom manifest rather than picking it up from
+  the default [krew index][index]
+- `--archive` overrides the download `url` specified in the plugin manifest and
+  uses a local file instead.
 
-```bash
-kubectl krew install --manifest=./foo.yaml --archive=./foo.zip
-```
+If the installation fails, run the command with `-v=4` flag for verbose logs.
+If your installation has succeeded, you should be able to run:
 
-This will install the `foo` plugin.
+    kubectl foo
 
-To see the plugin directory, find the `InstallPath`:
+If you made your archive file available to download on the Internet, run the
+same command without `--archive` and actually test downloading the file from
+`url`.
 
-```bash
-kubectl krew version
-```
+If you need other `platforms` definitions that don't match your current machine,
+you can use `KREW_OS` and/or `KREW_ARCH` environment variables. For example,
+if you're on a Linux machine, you can test Windows installation with:
 
-The installation target directory for the `foo` plugin is
-`<InstallPath>/<PluginName>/<PluginVersion>/`.
-There should always be only one version directory.
+    KREW_OS=windows krew install --manifest=[...]
 
-You can now run your plugin!
+After you have tested your plugin, remove it with `kubectl krew remove foo`.
 
-```bash
-kubectl foo
-```
+# Publishing Plugins
 
-### Cleaning up
-
-After you have tested the plugin, remove it with `kubectl krew remove foo`.
-
-### Publishing the Plugin
+## Submitting a plugin to krew
 
 After you have tested that the plugin can be installed and works you should
-create a pull request for the [Main Index][index].
-After the pull request gets accepted into the main index, the plugin will be available for
-all users.
+create a pull request to the [Krew Index][index] with your `<PLUGIN>.yaml`
+manifest file.
 
-Please make sure to include dependencies and extra configuration to run the
-plugin in the `caveats` section.
-The new plugin file should be submitted to the `plugins/` directory in the index.
+The new plugin file should be submitted to the `plugins/` directory in the
+index repository.
 
-### Updating a Published Plugin
+After the pull request gets accepted into the main index, the plugin will be
+available for all users.
 
-Create a pull request with the updated `uri` and `sha256`,
-it is also useful to change the `version` field so that users can distinguish
-the different versions.
+Please make sure to include dependencies of your plugin and extra configuration
+needed to run the plugin in the `caveats:` field.
+
+## Updating existing plugins
+
+When you have a newer version of your plugin, create a new pull request that
+updates `uri` and `sha256` fields of the plugin manifest file.
+
+Optionally, you can use the `version` field to match to your plugin's released
+version string.
 
 [index]: https://github.com/GoogleContainerTools/krew-index
+[plugins]: https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/


### PR DESCRIPTION
Note: used markdown-toc vscode extension to create the toc. It doesn't let
users to --no-firsth1, so I had to promote each heading by one.