### PR TITLE
upgrade: resolve krew version only on self-upgrade

### DIFF
--- a/cmd/krew/cmd/upgrade.go
+++ b/cmd/krew/cmd/upgrade.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/GoogleContainerTools/krew/pkg/environment"
 	"github.com/GoogleContainerTools/krew/pkg/index/indexscanner"
 	"github.com/GoogleContainerTools/krew/pkg/installation"
 
@@ -54,14 +53,6 @@ kubectl plugin upgrade foo bar"`,
 			pluginNames = args
 		}
 
-		execPath, err := os.Executable()
-		if err != nil {
-			return errors.Wrap(err, "could not get krew's own executable path")
-		}
-		executedKrewVersion, _, err := environment.GetExecutedVersion(paths.InstallPath(), execPath, environment.Realpath)
-		if err != nil {
-			return errors.Wrap(err, "failed to find current krew version")
-		}
 		for _, name := range pluginNames {
 			plugin, err := indexscanner.LoadPluginFileFromFS(paths.IndexPath(), name)
 			if err != nil {
@@ -69,7 +60,7 @@ kubectl plugin upgrade foo bar"`,
 			}
 
 			glog.V(2).Infof("Upgrading plugin: %s\n", plugin.Name)
-			err = installation.Upgrade(paths, plugin, executedKrewVersion)
+			err = installation.Upgrade(paths, plugin)
 			if ignoreUpgraded && err == installation.ErrIsAlreadyUpgraded {
 				fmt.Fprintf(os.Stderr, "Skipping plugin %s, it is already on the newest version\n", plugin.Name)
 				continue


### PR DESCRIPTION
Code cleanup: Pushes krew's version detection down the stack to run only when
it's needed.

Manually tested:

	I1014 10:46:26.337111   74266 install.go:150] Created symlink at "/Users/ahmetb/.krew/bin/kubectl-krew"
	I1014 10:46:26.337126   74266 upgrade.go:65] Starting old version cleanup
	I1014 10:46:26.337135   74266 upgrade.go:77] Handling removal for older version of krew
	I1014 10:46:26.337181   74266 upgrade.go:86] Detected running krew version=308989054b891cde0639d8405ea04a18c22e8461ed695b08163c52f1756b7d41
	I1014 10:46:26.337275   74266 upgrade.go:107] Remove old krew installation under "/Users/ahmetb/.krew/store/krew/247929916e4a325dc0ec3e4898d2ca11e966c9a23780dafd54cc598f4bed4b8f"
	Upgraded plugin: krew