### PR TITLE
hack: offer .tar.gz releases, use for posix

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ For macOS and Linux:
     ```sh
     (
       set -x; cd "$(mktemp -d)" &&
-      curl -fsSLO "https://github.com/GoogleContainerTools/krew/releases/download/v0.2.0/krew.{zip,yaml}" &&
-      unzip krew.zip &&
+      curl -fsSLO "https://github.com/GoogleContainerTools/krew/releases/download/v0.2.0/krew.{tar.gz,yaml}" &&
+      tar zxvf krew.tar.gz &&
       ./out/bin/krew-"$(uname | tr '[:upper:]' '[:lower:]')_amd64" install \
         --manifest=krew.yaml --archive=krew.zip
     )

--- a/hack/krew.yaml
+++ b/hack/krew.yaml
@@ -20,8 +20,8 @@ spec:
   version: "KREW_TAG"
   shortDescription: Package manager for kubectl plugins.
   platforms:
-  - uri: https://github.com/GoogleContainerTools/krew/releases/download/KREW_TAG/krew.zip
-    sha256: KREW_ZIP_CHECKSUM
+  - uri: https://github.com/GoogleContainerTools/krew/releases/download/KREW_TAG/krew.tar.gz
+    sha256: KREW_TAR_CHECKSUM
     bin: krew
     files:
     - from: out/bin/krew-darwin_amd64
@@ -30,8 +30,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/GoogleContainerTools/krew/releases/download/KREW_TAG/krew.zip
-    sha256: KREW_ZIP_CHECKSUM
+  - uri: https://github.com/GoogleContainerTools/krew/releases/download/KREW_TAG/krew.tar.gz
+    sha256: KREW_TAR_CHECKSUM
     bin: krew
     files:
     - from: out/bin/krew-linux_amd64
@@ -40,8 +40,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: https://github.com/GoogleContainerTools/krew/releases/download/KREW_TAG/krew.zip
-    sha256: KREW_ZIP_CHECKSUM
+  - uri: https://github.com/GoogleContainerTools/krew/releases/download/KREW_TAG/krew.tar.gz
+    sha256: KREW_TAR_CHECKSUM
     bin: krew
     files:
     - from: out/bin/krew-linux_arm


### PR DESCRIPTION
- create krew.tar.gz{,.sha256sum}
- use it in krew.yaml for linux/darwin
- use it in README.md for linux/darwin instalation (fixes #101)