### PR TITLE
Refactor --archive downloadOverwrite

### DIFF
--- a/cmd/krew/cmd/install.go
+++ b/cmd/krew/cmd/install.go
@@ -30,7 +30,7 @@ import (
 
 func init() {
 	var forceHEAD *bool
-	var manifest, forceDownloadFile *string
+	var manifest, downloadFileOverwrite *string
 
 	// installCmd represents the install command
 	installCmd := &cobra.Command{
@@ -61,7 +61,7 @@ All plugins will be downloaded and made available to: "kubectl plugin <name>"`,
 				return errors.New("must specify either specify stdin or --manifest or args")
 			}
 
-			if *forceDownloadFile != "" && *manifest == "" {
+			if *downloadFileOverwrite != "" && *manifest == "" {
 				return errors.New("--archive can be specified only with --manifest")
 			}
 
@@ -105,13 +105,13 @@ All plugins will be downloaded and made available to: "kubectl plugin <name>"`,
 			// Do install
 			for _, plugin := range install {
 				fmt.Fprintf(os.Stderr, "Installing plugin: %s\n", plugin.Name)
-				err := installation.Install(paths, plugin, *forceHEAD, *forceDownloadFile)
+				err := installation.Install(paths, plugin, *forceHEAD, *downloadFileOverwrite)
 				if err == installation.ErrIsAlreadyInstalled {
 					glog.Warningf("Skipping plugin %s, it is already installed", plugin.Name)
 					continue
 				}
 				if err != nil {
-					glog.Warningf("failed to install plugin %q", plugin.Name)
+					glog.Warningf("failed to install plugin %q, err: %s", plugin.Name, err)
 					failed = append(failed, plugin.Name)
 					continue
 				}
@@ -136,7 +136,7 @@ All plugins will be downloaded and made available to: "kubectl plugin <name>"`,
 
 	forceHEAD = installCmd.Flags().Bool("HEAD", false, "Force HEAD if versioned and HEAD installs are possible.")
 	manifest = installCmd.Flags().String("manifest", "", "(Development-only) specify plugin manifest directly.")
-	forceDownloadFile = installCmd.Flags().String("archive", "", "(Development-only) force all downloads to use the specified file")
+	downloadFileOverwrite = installCmd.Flags().String("archive", "", "(Development-only) force all downloads to use the specified file")
 
 	rootCmd.AddCommand(installCmd)
 }

--- a/pkg/download/fetch.go
+++ b/pkg/download/fetch.go
@@ -38,11 +38,11 @@ func (HTTPFetcher) Get(uri string) (io.ReadCloser, error) {
 	return resp.Body, nil
 }
 
-type fileFetcher struct{ f string }
+type fileFetcher struct{}
 
-func (f fileFetcher) Get(_ string) (io.ReadCloser, error) {
-	return os.Open(f.f)
+func (fileFetcher) Get(file string) (io.ReadCloser, error) {
+	return os.Open(file)
 }
 
 // NewFileFetcher returns a local file reader.
-func NewFileFetcher(path string) Fetcher { return fileFetcher{f: path} }
+func NewFileFetcher() Fetcher { return fileFetcher{} }

--- a/pkg/installation/install.go
+++ b/pkg/installation/install.go
@@ -42,7 +42,7 @@ const (
 	krewPluginName = "krew"
 )
 
-func downloadAndMove(version, uri string, fos []index.FileOperation, downloadPath, installPath, forceDownloadFile string) (dst string, err error) {
+func downloadAndMove(version, uri string, fos []index.FileOperation, downloadPath, installPath, downloadFileOverwrite string) (dst string, err error) {
 	glog.V(3).Infof("Creating download dir %q", downloadPath)
 	if err = os.MkdirAll(downloadPath, 0755); err != nil {
 		return "", errors.Wrapf(err, "could not create download path %q", downloadPath)
@@ -50,8 +50,9 @@ func downloadAndMove(version, uri string, fos []index.FileOperation, downloadPat
 	defer os.RemoveAll(downloadPath)
 
 	var fetcher download.Fetcher = download.HTTPFetcher{}
-	if forceDownloadFile != "" {
-		fetcher = download.NewFileFetcher(forceDownloadFile)
+	if downloadFileOverwrite != "" {
+		uri = downloadFileOverwrite
+		fetcher = download.NewFileFetcher()
 	}
 
 	if version == headVersion {
@@ -70,7 +71,7 @@ func downloadAndMove(version, uri string, fos []index.FileOperation, downloadPat
 
 // Install will download and install a plugin. The operation tries
 // to not get the plugin dir in a bad state if it fails during the process.
-func Install(p environment.Paths, plugin index.Plugin, forceHEAD bool, forceDownloadFile string) error {
+func Install(p environment.Paths, plugin index.Plugin, forceHEAD bool, downloadFileOverwrite string) error {
 	glog.V(2).Infof("Looking for installed versions")
 	_, ok, err := findInstalledPluginVersion(p.InstallPath(), p.BinPath(), plugin.Name)
 	if err != nil {
@@ -85,11 +86,11 @@ func Install(p environment.Paths, plugin index.Plugin, forceHEAD bool, forceDown
 	if err != nil {
 		return err
 	}
-	return install(plugin.Name, version, uri, bin, p, fos, forceDownloadFile)
+	return install(plugin.Name, version, uri, bin, p, fos, downloadFileOverwrite)
 }
 
-func install(plugin, version, uri, bin string, p environment.Paths, fos []index.FileOperation, forceDownloadFile string) error {
-	dst, err := downloadAndMove(version, uri, fos, filepath.Join(p.DownloadPath(), plugin), p.PluginInstallPath(plugin), forceDownloadFile)
+func install(plugin, version, uri, bin string, p environment.Paths, fos []index.FileOperation, downloadFileOverwrite string) error {
+	dst, err := downloadAndMove(version, uri, fos, filepath.Join(p.DownloadPath(), plugin), p.PluginInstallPath(plugin), downloadFileOverwrite)
 	if err != nil {
 		return errors.Wrap(err, "failed to dowload and move during installation")
 	}


### PR DESCRIPTION
This PR:
- Add error logging for installations
- Rename `forceDownloadFile` to `downloadFileOverwrite`
- Replace uri with `downloadFileOverwrite` to generate propper logging statements
- Refactor file fetcher to use URI
/fixes #109 