### PR TITLE
hack: plumb in TAG_NAME and SHORT_SHA

### DIFF
--- a/hack/cloudbuild-release.yaml
+++ b/hack/cloudbuild-release.yaml
@@ -18,6 +18,7 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     args: ['build', '-t', 'builder', '-f', 'hack/Dockerfile.build', '.']
   - name: 'builder'
+    env: ['TAG_NAME=${TAG_NAME}', 'SHORT_SHA=${SHORT_SHA}']
   - name: 'gcr.io/cloud-builders/gsutil'
     args: ['-m', 'cp', '-r', 'out/*', 'gs://krew/$TAG_NAME/']
   - name: 'gcr.io/cloud-builders/gsutil'

--- a/hack/cloudbuild.yaml
+++ b/hack/cloudbuild.yaml
@@ -17,6 +17,7 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     args: ['build', '-t', 'builder', '-f', 'hack/Dockerfile.build', '.']
   - name: 'builder'
+    env: ['TAG_NAME=${TAG_NAME}', 'SHORT_SHA=${SHORT_SHA}']
   - name: 'gcr.io/cloud-builders/gsutil'
     args: ['-m', 'cp', '-r', 'out/*', 'gs://krew/builds/$SHORT_SHA/']
 options:


### PR DESCRIPTION
Due to lack of plumbing of GCB, v0.2.0 binary was not stamped correctly.