### PR TITLE
Fix typos in user guide

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -95,12 +95,12 @@ downloaded git archive. Also, untagged plugins are very likely to be unstable.
 
 ## Listing Installed Plugins
 
-All plugins available to `kubectl` (including those not installed via krew) can
-listed using:
+All plugins available to `kubectl` (including those not installed via `krew`) can
+be listed using:
 
-    kubectl krew list
+    kubectl plugin list
 
-To list all plugins install via `krew`, run:
+To list all plugins installed via `krew`, run:
 
     kubectl krew list
 


### PR DESCRIPTION
Encountered some typos in the user guide, including a wrong command, which might be confusing otherwise.