### PR TITLE
Add `spec.homepage` field to the plugin manifest

### DIFF
--- a/cmd/krew/cmd/info.go
+++ b/cmd/krew/cmd/info.go
@@ -68,14 +68,14 @@ func printPluginInfo(out io.Writer, plugin index.Plugin) {
 			fmt.Fprintf(out, "SHA256: %s\n", platform.Sha256)
 		}
 	}
-	if plugin.Spec.Description != "" {
-		fmt.Fprintf(out, "DESCRIPTION: \n%s\n", plugin.Spec.Description)
-	}
 	if plugin.Spec.Version != "" {
 		fmt.Fprintf(out, "VERSION: %s\n", plugin.Spec.Version)
 	}
 	if plugin.Spec.Homepage != "" {
 		fmt.Fprintf(out, "HOMEPAGE: %s\n", plugin.Spec.Homepage)
+	}
+	if plugin.Spec.Description != "" {
+		fmt.Fprintf(out, "DESCRIPTION: \n%s\n", plugin.Spec.Description)
 	}
 	if plugin.Spec.Caveats != "" {
 		fmt.Fprintln(out, prepCaveats(plugin.Spec.Caveats))

--- a/cmd/krew/cmd/info.go
+++ b/cmd/krew/cmd/info.go
@@ -74,6 +74,9 @@ func printPluginInfo(out io.Writer, plugin index.Plugin) {
 	if plugin.Spec.Version != "" {
 		fmt.Fprintf(out, "VERSION: %s\n", plugin.Spec.Version)
 	}
+	if plugin.Spec.Homepage != "" {
+		fmt.Fprintf(out, "HOMEPAGE: %s\n", plugin.Spec.Homepage)
+	}
 	if plugin.Spec.Caveats != "" {
 		fmt.Fprintln(out, prepCaveats(plugin.Spec.Caveats))
 	}

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -109,6 +109,7 @@ spec:
       to: "."               # '.' refers to the root of plugin install directory
     bin: "./kubectl-foo"  # path to the plugin executable after copying files above
   shortDescription: Prints the environment variables.
+  homepage: https://github.com/GoogleContainerTools/krew # optional, url for the project homepage
   # (optional) use caveats field to show post-installation recommendations
   caveats: |
     This plugin needs the following programs:

--- a/pkg/index/indexscanner/testdata/testindex/plugins/foo.yaml
+++ b/pkg/index/indexscanner/testdata/testindex/plugins/foo.yaml
@@ -33,4 +33,4 @@ spec:
       matchLabels:
         os: "windows"
   shortDescription: "exists"
-
+  homepage: "https://example.com/foo"

--- a/pkg/index/types.go
+++ b/pkg/index/types.go
@@ -33,6 +33,7 @@ type PluginSpec struct {
 	ShortDescription string `json:"shortDescription,omitempty"`
 	Description      string `json:"description,omitempty"`
 	Caveats          string `json:"caveats,omitempty"`
+	Homepage         string `json:"homepage,omitempty"`
 
 	Platforms []Platform `json:"platforms,omitempty"`
 }

--- a/pkg/index/validate.go
+++ b/pkg/index/validate.go
@@ -15,6 +15,7 @@
 package index
 
 import (
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -72,6 +73,11 @@ func (p Plugin) Validate(name string) error {
 	for _, pl := range p.Spec.Platforms {
 		if err := pl.Validate(); err != nil {
 			return errors.Wrapf(err, "platform (%+v) is badly constructed", pl)
+		}
+	}
+	if p.Spec.Homepage != "" {
+		if _, err := url.ParseRequestURI(p.Spec.Homepage); err != nil {
+			return errors.Wrapf(err, "the homepage url %q is not a valid url", p.Spec.Homepage)
 		}
 	}
 	return nil

--- a/pkg/index/validate.go
+++ b/pkg/index/validate.go
@@ -15,7 +15,6 @@
 package index
 
 import (
-	"net/url"
 	"regexp"
 	"strings"
 
@@ -73,11 +72,6 @@ func (p Plugin) Validate(name string) error {
 	for _, pl := range p.Spec.Platforms {
 		if err := pl.Validate(); err != nil {
 			return errors.Wrapf(err, "platform (%+v) is badly constructed", pl)
-		}
-	}
-	if p.Spec.Homepage != "" {
-		if _, err := url.ParseRequestURI(p.Spec.Homepage); err != nil {
-			return errors.Wrapf(err, "the homepage url %q is not a valid url", p.Spec.Homepage)
 		}
 	}
 	return nil

--- a/pkg/index/validate_test.go
+++ b/pkg/index/validate_test.go
@@ -112,6 +112,7 @@ func TestPlugin_Validate(t *testing.T) {
 					ShortDescription: "short",
 					Description:      "",
 					Caveats:          "",
+					Homepage:         "",
 					Platforms: []Platform{{
 						Head:     "http://example.com",
 						URI:      "",
@@ -238,6 +239,54 @@ func TestPlugin_Validate(t *testing.T) {
 				},
 			},
 			pluginName: "../foo",
+			wantErr:    true,
+		},
+		{
+			name: "valid homepage url",
+			fields: fields{
+				TypeMeta:   metav1.TypeMeta{APIVersion: currentAPIVersion},
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: PluginSpec{
+					Version:          "",
+					ShortDescription: "short",
+					Description:      "",
+					Caveats:          "",
+					Homepage:         "http://example.com/foo/bar",
+					Platforms: []Platform{{
+						Head:     "http://example.com",
+						URI:      "",
+						Sha256:   "",
+						Selector: nil,
+						Files:    []FileOperation{{"", ""}},
+						Bin:      "foo",
+					}},
+				},
+			},
+			pluginName: "foo",
+			wantErr:    false,
+		},
+		{
+			name: "invalid homepage url",
+			fields: fields{
+				TypeMeta:   metav1.TypeMeta{APIVersion: currentAPIVersion},
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: PluginSpec{
+					Version:          "",
+					ShortDescription: "short",
+					Description:      "",
+					Caveats:          "",
+					Homepage:         "this-is-an-invalid-url",
+					Platforms: []Platform{{
+						Head:     "http://example.com",
+						URI:      "",
+						Sha256:   "",
+						Selector: nil,
+						Files:    []FileOperation{{"", ""}},
+						Bin:      "foo",
+					}},
+				},
+			},
+			pluginName: "foo",
 			wantErr:    true,
 		},
 	}

--- a/pkg/index/validate_test.go
+++ b/pkg/index/validate_test.go
@@ -241,54 +241,6 @@ func TestPlugin_Validate(t *testing.T) {
 			pluginName: "../foo",
 			wantErr:    true,
 		},
-		{
-			name: "valid homepage url",
-			fields: fields{
-				TypeMeta:   metav1.TypeMeta{APIVersion: currentAPIVersion},
-				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-				Spec: PluginSpec{
-					Version:          "",
-					ShortDescription: "short",
-					Description:      "",
-					Caveats:          "",
-					Homepage:         "http://example.com/foo/bar",
-					Platforms: []Platform{{
-						Head:     "http://example.com",
-						URI:      "",
-						Sha256:   "",
-						Selector: nil,
-						Files:    []FileOperation{{"", ""}},
-						Bin:      "foo",
-					}},
-				},
-			},
-			pluginName: "foo",
-			wantErr:    false,
-		},
-		{
-			name: "invalid homepage url",
-			fields: fields{
-				TypeMeta:   metav1.TypeMeta{APIVersion: currentAPIVersion},
-				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-				Spec: PluginSpec{
-					Version:          "",
-					ShortDescription: "short",
-					Description:      "",
-					Caveats:          "",
-					Homepage:         "this-is-an-invalid-url",
-					Platforms: []Platform{{
-						Head:     "http://example.com",
-						URI:      "",
-						Sha256:   "",
-						Selector: nil,
-						Files:    []FileOperation{{"", ""}},
-						Bin:      "foo",
-					}},
-				},
-			},
-			pluginName: "foo",
-			wantErr:    true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR adds `spec.homepage` field to the plugin manifest.

/close #157 

---

The `spec.homepage` field of the plugin manifest defines the url of the
plugin project homepage. The field value should be a valid url.

In addition, if the `spec.homepage` field is defined in plugin manifest,
`kubectl krew info` command displays that field value as HOMEPAGE as follows:

    $ kubectl krew info krew
    NAME: krew
    URI: https://storage.googleapis.com/krew/v0.2.1/krew.tar.gz
    SHA256: dc2f2e1ec8a0acb6f3e23580d4a8b38c44823e948c40342e13ff6e8e12edb15a
    VERSION: v0.2.1
    HOMEPAGE: https://github.com/GoogleContainerTools/krew
    ...